### PR TITLE
fix: correctness bugs and event-loop stalls from project review

### DIFF
--- a/desktop/src-tauri/src/sidecar.rs
+++ b/desktop/src-tauri/src/sidecar.rs
@@ -323,11 +323,14 @@ pub async fn spawn(app: AppHandle) -> Result<SidecarInfo, SidecarError> {
 
     let deadline = Instant::now() + Duration::from_secs(30);
     let info = loop {
-        if Instant::now() > deadline {
-            let _ = child.start_kill();
-            return Err(SidecarError::Timeout);
-        }
         tokio::select! {
+            // A silent-but-alive child never produces a line or an exit, so
+            // the timeout must be a select branch of its own — checking the
+            // deadline at the top of the loop only fires after output arrives.
+            _ = tokio::time::sleep_until(deadline) => {
+                let _ = child.start_kill();
+                return Err(SidecarError::Timeout);
+            }
             line = reader.next_line() => {
                 match line {
                     Ok(Some(text)) => {

--- a/desktop/src/components/settings/SettingsSheet.tsx
+++ b/desktop/src/components/settings/SettingsSheet.tsx
@@ -447,8 +447,12 @@ function CacheTab({ open }: { open: boolean }) {
   const handleClear = async (scope: "expired" | "all") => {
     setClearing(scope);
     try {
+      // "Clear all" also wipes the whole-PDF cache (translated PDFs), not
+      // just the paragraph cache; "Clear expired" is paragraph-only (the PDF
+      // cache has no TTL).
+      const target = scope === "all" ? "all" : "paragraph";
       const r = await api.delete<{ removed: number; scope: string }>(
-        `/config/cache?scope=${scope}`,
+        `/config/cache?scope=${scope}&target=${target}`,
       );
       toast.success(`Cleared ${r.removed} ${scope} entries`);
       await refresh();

--- a/desktop/src/hooks/useRagAsk.ts
+++ b/desktop/src/hooks/useRagAsk.ts
@@ -126,6 +126,12 @@ export function useRagAsk() {
           }
         },
       });
+      // Stream ended without a terminal event (sidecar died mid-answer).
+      setState((s) =>
+        s.status === "asking"
+          ? { ...s, status: "error", error: "Answer stream ended unexpectedly" }
+          : s,
+      );
     } catch (e) {
       setState((s) => ({
         ...s,

--- a/desktop/src/hooks/useRagIndex.ts
+++ b/desktop/src/hooks/useRagIndex.ts
@@ -68,6 +68,12 @@ export function useRagIndex() {
           }
         },
       });
+      // Stream ended without a terminal event (sidecar died mid-index).
+      setState((s) =>
+        s.status === "indexing"
+          ? { ...s, status: "error", error: "Index stream ended unexpectedly" }
+          : s,
+      );
     } catch (e) {
       setState((s) => ({
         ...s,

--- a/desktop/src/hooks/useTranslation.ts
+++ b/desktop/src/hooks/useTranslation.ts
@@ -248,6 +248,18 @@ export function useTranslation() {
             }
           },
         });
+        // The stream can end without a terminal event (sidecar crash or
+        // restart mid-job). Without this, the overlay stays on "running"
+        // forever. Functional update so a terminal event that did land wins.
+        setState((s) =>
+          s.status === "running"
+            ? {
+                ...s,
+                status: "error",
+                error: "Translation stream ended unexpectedly",
+              }
+            : s,
+        );
       } catch (e) {
         setState((s) => ({
           ...s,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
 
     # Translation services
     "openai>=1.3.0,<2.0.0",
-    "google-generativeai>=0.3.0,<1.0.0",
+    "google-genai>=1.0.0,<2.0.0",
     "anthropic>=0.40.0,<1.0.0",
     "tiktoken>=0.5.0,<1.0.0",
 

--- a/src/desktop_pdf_translator/api/routes/config.py
+++ b/src/desktop_pdf_translator/api/routes/config.py
@@ -1,8 +1,10 @@
 """Configuration + API key management endpoints."""
 
+import asyncio
 import logging
 from fastapi import APIRouter, Depends, HTTPException
 
+from ...processors.pdf_cache import get_pdf_cache
 from ...config import (
     AppSettings,
     LanguageCode,
@@ -201,13 +203,22 @@ async def get_cache_stats() -> CacheStatsResponse:
 
 
 @router.delete("/cache", response_model=CacheClearResponse)
-async def clear_cache(scope: str = "all") -> CacheClearResponse:
-    """Clear the on-disk translation cache. `scope=expired` only reaps stale
-    entries; `scope=all` wipes everything (e.g. when the user changes models)."""
-    cache = get_translation_cache()
-    if scope == "expired":
-        removed = cache.clear_expired()
-    else:
-        scope = "all"
-        removed = cache.clear_all()
+async def clear_cache(scope: str = "all", target: str = "paragraph") -> CacheClearResponse:
+    """Clear the on-disk translation caches.
+
+    `scope=expired` only reaps stale entries; `scope=all` wipes everything
+    (e.g. when the user changes models). `target` picks which cache:
+    `paragraph` (default, backward compatible), `pdf` (whole-PDF cache), or
+    `all` (both). The PDF cache has no TTL, so `scope=expired` doesn't touch it.
+    """
+    removed = 0
+    if target in ("paragraph", "all"):
+        cache = get_translation_cache()
+        if scope == "expired":
+            removed += await asyncio.to_thread(cache.clear_expired)
+        else:
+            scope = "all"
+            removed += await asyncio.to_thread(cache.clear_all)
+    if target in ("pdf", "all") and scope != "expired":
+        removed += await asyncio.to_thread(get_pdf_cache().clear_all)
     return CacheClearResponse(removed=removed, scope=scope)

--- a/src/desktop_pdf_translator/api/routes/rag.py
+++ b/src/desktop_pdf_translator/api/routes/rag.py
@@ -27,12 +27,21 @@ _rag_chain: Optional[EnhancedRAGChain] = None
 _init_lock = asyncio.Lock()
 
 
-async def _get_chain() -> EnhancedRAGChain:
+def _build_chain() -> EnhancedRAGChain:
+    """Blocking: constructs ChromaDB + loads the SentenceTransformer model."""
     global _vector_store, _rag_chain
+    _vector_store = ChromaDBManager()
+    _rag_chain = EnhancedRAGChain(_vector_store)
+    return _rag_chain
+
+
+async def _get_chain() -> EnhancedRAGChain:
     async with _init_lock:
         if _rag_chain is None:
-            _vector_store = ChromaDBManager()
-            _rag_chain = EnhancedRAGChain(_vector_store)
+            # First use loads the embedding model (seconds of CPU + disk).
+            # Run it off the event loop so the rest of the sidecar — health
+            # checks, translation SSE — stays responsive.
+            await asyncio.to_thread(_build_chain)
         return _rag_chain
 
 
@@ -65,7 +74,8 @@ async def _run_index(job: Job, payload: IndexRequest) -> None:
 
         await job.emit("progress", {"stage": "Extracting text", "progress": 20})
         processor = ScientificPDFProcessor()
-        chunks = await processor.process_pdf(file_path)
+        # Blocking fitz/camelot/pdfplumber work — keep it off the event loop.
+        chunks = await asyncio.to_thread(processor.process_pdf, file_path)
 
         if job.cancelled:
             await job.finish("cancelled", {})

--- a/src/desktop_pdf_translator/api/routes/translation.py
+++ b/src/desktop_pdf_translator/api/routes/translation.py
@@ -155,6 +155,9 @@ async def reprioritize_translation(job_id: str, visible_page: int) -> None:
 
 # (service, lang_in, lang_out) → already warmed in this sidecar process.
 _WARMED: set[tuple[str, str, str]] = set()
+# Keys with a warm-up currently in flight, so concurrent /prewarm calls don't
+# schedule duplicate work. Removed on completion (success or failure).
+_WARMING: set[tuple[str, str, str]] = set()
 _WARM_LOCK = threading.Lock()
 
 # Strong refs to in-flight prewarm tasks. asyncio.create_task only holds a weak
@@ -162,9 +165,13 @@ _WARM_LOCK = threading.Lock()
 _PREWARM_TASKS: set[asyncio.Task] = set()
 
 
-def _warm_translator(service: TranslationService, lang_in: str, lang_out: str) -> str:
+def _warm_translator(
+    service: TranslationService, lang_in: str, lang_out: str
+) -> tuple[bool, str]:
     """Blocking warm-up. Runs in a worker thread (asyncio.to_thread) so the
-    endpoint returns immediately even when Argos has to download its ~80 MB pack."""
+    endpoint returns immediately even when Argos has to download its ~80 MB
+    pack. Returns (ok, message); a failed warm-up must NOT be recorded as
+    warm so the next /prewarm can retry (e.g. transient network failure)."""
     try:
         translator = TranslatorFactory.create_translator(
             service=service, lang_in=lang_in, lang_out=lang_out
@@ -186,10 +193,10 @@ def _warm_translator(service: TranslationService, lang_in: str, lang_out: str) -
                 translator.validate_configuration()
             except Exception:
                 pass
-        return f"Warmed {service.value}"
+        return True, f"Warmed {service.value}"
     except Exception as e:
         logger.warning("Pre-warm failed for %s: %s", service, e)
-        return f"Pre-warm failed: {e}"
+        return False, f"Pre-warm failed: {e}"
 
 
 @router.post("/prewarm", response_model=PrewarmResponse)
@@ -203,22 +210,37 @@ async def prewarm(payload: PrewarmRequest) -> PrewarmResponse:
     key = (service.value, payload.source_lang.value, payload.target_lang.value)
     with _WARM_LOCK:
         already = key in _WARMED
+        in_flight = key in _WARMING
+        if not already and not in_flight:
+            _WARMING.add(key)
 
     if already:
         return PrewarmResponse(
             service=service.value, warmed=True, cached=True, message="Already warm"
         )
+    if in_flight:
+        return PrewarmResponse(
+            service=service.value,
+            warmed=False,
+            cached=False,
+            message="Warm-up already in progress",
+        )
 
     # Don't block the HTTP response on the pack download. Schedule and return.
     async def _run() -> None:
-        msg = await asyncio.to_thread(
-            _warm_translator,
-            service,
-            payload.source_lang.value,
-            payload.target_lang.value,
-        )
+        try:
+            ok, msg = await asyncio.to_thread(
+                _warm_translator,
+                service,
+                payload.source_lang.value,
+                payload.target_lang.value,
+            )
+        except Exception as exc:  # noqa: BLE001 — never leave key stuck in _WARMING
+            ok, msg = False, f"Pre-warm crashed: {exc}"
         with _WARM_LOCK:
-            _WARMED.add(key)
+            _WARMING.discard(key)
+            if ok:
+                _WARMED.add(key)
         logger.info("Pre-warm complete: %s (%s)", service.value, msg)
 
     task = asyncio.create_task(_run())

--- a/src/desktop_pdf_translator/api/server.py
+++ b/src/desktop_pdf_translator/api/server.py
@@ -14,6 +14,7 @@ Any process that can read this stdout line can talk to the sidecar.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import shutil
 import socket
@@ -118,6 +119,28 @@ def _sweep_orphan_translate_dirs(max_age_seconds: int = 3600) -> int:
     return cleaned
 
 
+def _gc_translation_cache() -> None:
+    """Startup GC for the paragraph cache: reap expired rows, then enforce the
+    size cap (which was previously declared but never enforced anywhere)."""
+    try:
+        from ..translators.translation_cache import get_translation_cache
+
+        cache = get_translation_cache()
+        expired = cache.clear_expired()
+        evicted = cache.enforce_size_cap()
+        if expired or evicted:
+            logger.info(
+                "Translation cache GC: %d expired, %d evicted for size",
+                expired, evicted,
+            )
+    except Exception as exc:  # noqa: BLE001 — GC is best-effort
+        logger.warning("Translation cache GC failed: %s", exc)
+
+
+# Strong ref so the GC task isn't reaped mid-flight (create_task holds weak refs).
+_startup_tasks: set[asyncio.Task] = set()
+
+
 @asynccontextmanager
 async def _lifespan(app: FastAPI):
     logger.info("Sidecar starting; loading settings…")
@@ -131,6 +154,10 @@ async def _lifespan(app: FastAPI):
             name="argos-prewarm",
             daemon=True,
         ).start()
+    # Paragraph-cache GC in the background so startup isn't delayed.
+    gc_task = asyncio.create_task(asyncio.to_thread(_gc_translation_cache))
+    _startup_tasks.add(gc_task)
+    gc_task.add_done_callback(_startup_tasks.discard)
     yield
     logger.info("Sidecar shutting down")
 

--- a/src/desktop_pdf_translator/config/models.py
+++ b/src/desktop_pdf_translator/config/models.py
@@ -215,17 +215,3 @@ class FileMetadata(BaseModel):
     service_used: Optional[TranslationService] = None
     processing_time_seconds: Optional[float] = None
     translation_quality_score: Optional[float] = None
-    
-    @validator('file_size_mb')
-    def validate_file_size(cls, v, values):
-        """Validate file size against limits."""
-        # This will be checked against AppSettings.translation.max_file_size_mb
-        # in the actual processing logic
-        return v
-    
-    @validator('page_count') 
-    def validate_page_count(cls, v, values):
-        """Validate page count against limits."""
-        # This will be checked against AppSettings.translation.max_pages
-        # in the actual processing logic
-        return v

--- a/src/desktop_pdf_translator/processors/processor.py
+++ b/src/desktop_pdf_translator/processors/processor.py
@@ -10,7 +10,7 @@ import tempfile
 import time
 import uuid
 from pathlib import Path
-from typing import AsyncGenerator, Optional, Dict, Any
+from typing import AsyncGenerator, Optional
 
 import fitz  # PyMuPDF
 
@@ -57,6 +57,22 @@ def _log_cache_store_failure(task: "asyncio.Task") -> None:
 _TEMP_DIR_PREFIX = "pdfusion-translate-"
 _previous_output_dir: Optional[Path] = None
 _pending_temp_cleanups: "set[asyncio.Task]" = set()
+
+# Ownership tracking so a new job never deletes a dir a still-running job is
+# writing into (two /translate calls can overlap: rapid re-click, or a cancel
+# whose worker is still draining). All mutations happen on the event loop, so
+# no locking is needed.
+_active_output_dirs: "set[Path]" = set()
+_deferred_cleanups: "set[Path]" = set()
+
+
+def _release_output_dir(path: Path) -> None:
+    """Mark a per-job temp dir as no longer owned by a running job. If a newer
+    job superseded it while it was still active, run its deferred cleanup."""
+    _active_output_dirs.discard(path)
+    if path in _deferred_cleanups:
+        _deferred_cleanups.discard(path)
+        _schedule_temp_cleanup(path)
 
 
 def _is_owned_temp_dir(path: Path) -> bool:
@@ -169,7 +185,6 @@ class PDFProcessor:
         """Initialize PDF processor."""
         self.settings = get_settings()
         self.session_id = None
-        self._current_task = None
         # Captured at process_pdf() entry so the API layer can locate the
         # latest rolling translated PDF when the user cancels mid-run.
         self._output_dir: Optional[Path] = None
@@ -215,7 +230,8 @@ class PDFProcessor:
         """
         self.session_id = str(uuid.uuid4())
         start_time = time.time()
-        
+        owns_output_dir = False
+
         try:
             # Use provided languages or fallback to config
             source_lang = source_lang or self.settings.translation.default_source_lang
@@ -243,10 +259,17 @@ class PDFProcessor:
             global _previous_output_dir
             if output_dir is None:
                 output_dir = Path(tempfile.mkdtemp(prefix=_TEMP_DIR_PREFIX))
+                owns_output_dir = True
+                _active_output_dirs.add(output_dir)
                 prev = _previous_output_dir
                 _previous_output_dir = output_dir
                 if prev is not None and prev != output_dir:
-                    _schedule_temp_cleanup(prev)
+                    if prev in _active_output_dirs:
+                        # The previous job is still running — defer its dir's
+                        # cleanup until that job releases it.
+                        _deferred_cleanups.add(prev)
+                    else:
+                        _schedule_temp_cleanup(prev)
             output_dir.mkdir(parents=True, exist_ok=True)
             self._output_dir = output_dir
             self._input_stem = file_path.stem
@@ -574,7 +597,10 @@ class PDFProcessor:
                 recoverable=False
             )
             raise ProcessingError(f"Processing failed: {e}", details=str(e))
-    
+        finally:
+            if owns_output_dir and output_dir is not None:
+                _release_output_dir(output_dir)
+
     def _resolve_model_id(self, service: TranslationService) -> Optional[str]:
         """Model string used in PDF-cache keys. Mirrors the per-service config
         so changing model (e.g. gpt-4 → gpt-4o) invalidates cache entries
@@ -631,7 +657,10 @@ class PDFProcessor:
                 doc.close()
             except Exception as e:
                 raise FileValidationError(f"Cannot open PDF file: {e}")
-            
+
+            if page_count == 0:
+                raise FileValidationError("PDF has no pages")
+
             # Check page count limit
             if page_count > self.settings.translation.max_pages:
                 raise FileValidationError(
@@ -891,7 +920,11 @@ class PDFProcessor:
                         output_dir
                         / f"{file_path.stem}_translated_v{completed_count:03d}.pdf"
                     )
-                    self._rebuild_sparse_rolling_pdf(
+                    # PyMuPDF merge is blocking (~50-100 ms, grows with page
+                    # count) — run it off the event loop so SSE delivery and
+                    # other requests aren't stalled per chunk.
+                    await asyncio.to_thread(
+                        self._rebuild_sparse_rolling_pdf,
                         rolling_path,
                         original_path=file_path,
                         chunks=chunks,
@@ -1217,12 +1250,6 @@ class PDFProcessor:
         
         return None
     
-    def cancel_processing(self):
-        """Cancel current processing task."""
-        if self._current_task and not self._current_task.done():
-            self._current_task.cancel()
-            logger.info(f"Cancelled processing session {self.session_id}")
-
     def get_partial_translated_file(self) -> Optional[Path]:
         """Latest rolling translated PDF written so far, or None if no chunk
         has finished. Used by the API layer to surface a partial result on
@@ -1252,10 +1279,3 @@ class PDFProcessor:
                 stale.unlink()
             except OSError as exc:
                 logger.warning("Could not delete intermediate %s: %s", stale, exc)
-    
-    def get_session_info(self) -> Dict[str, Any]:
-        """Get information about current processing session."""
-        return {
-            "session_id": self.session_id,
-            "settings": self.settings.dict()
-        }

--- a/src/desktop_pdf_translator/rag/document_processor.py
+++ b/src/desktop_pdf_translator/rag/document_processor.py
@@ -4,7 +4,6 @@ Handles equations, tables, figures, and complex scientific content.
 """
 
 import logging
-import asyncio
 from pathlib import Path
 from typing import List, Dict, Any, Optional, Tuple
 
@@ -171,7 +170,7 @@ class ScientificPDFProcessor:
         self.elements = []
         self.page_layouts = {}
         
-    async def process_pdf(self, pdf_path: Path) -> List[Dict[str, Any]]:
+    def process_pdf(self, pdf_path: Path) -> List[Dict[str, Any]]:
         """
         Process PDF and extract structured elements.
         
@@ -190,12 +189,12 @@ class ScientificPDFProcessor:
             # Process each page
             for page_num in range(len(doc)):
                 page = doc[page_num]
-                await self._process_page(page, page_num, pdf_path)
+                self._process_page(page, page_num, pdf_path)
                 
             doc.close()
             
             # Create contextual chunks
-            chunks = await self._create_contextual_chunks()
+            chunks = self._create_contextual_chunks()
             
             logger.info(f"Processed {len(self.elements)} elements into {len(chunks)} chunks")
             return chunks
@@ -204,7 +203,7 @@ class ScientificPDFProcessor:
             logger.error(f"PDF processing failed: {e}")
             raise
     
-    async def _process_page(self, page: fitz.Page, page_num: int, pdf_path: Path):
+    def _process_page(self, page: fitz.Page, page_num: int, pdf_path: Path):
         """Process a single page and extract elements."""
         
         # Get page text with formatting
@@ -212,13 +211,13 @@ class ScientificPDFProcessor:
         page_text = page.get_text()
         
         # Extract text elements
-        await self._extract_text_elements(text_dict, page_num)
+        self._extract_text_elements(text_dict, page_num)
         
         # Extract images (potential equations and figures)
-        await self._extract_images(page, page_num, page_text)
+        self._extract_images(page, page_num, page_text)
         
         # Extract tables
-        await self._extract_tables(page, page_num, pdf_path)
+        self._extract_tables(page, page_num, pdf_path)
         
         # Store page layout
         self.page_layouts[page_num] = {
@@ -227,7 +226,7 @@ class ScientificPDFProcessor:
             'text': page_text
         }
     
-    async def _extract_text_elements(self, text_dict: Dict, page_num: int):
+    def _extract_text_elements(self, text_dict: Dict, page_num: int):
         """Extract and analyze text elements."""
         
         for block in text_dict.get("blocks", []):
@@ -253,7 +252,7 @@ class ScientificPDFProcessor:
                     element.analyze_text_type()
                     self.elements.append(element)
     
-    async def _extract_images(self, page: fitz.Page, page_num: int, page_text: str):
+    def _extract_images(self, page: fitz.Page, page_num: int, page_text: str):
         """Extract images that might be equations or figures."""
         
         image_list = page.get_images()
@@ -294,7 +293,7 @@ class ScientificPDFProcessor:
             except Exception as e:
                 logger.warning(f"Failed to process image {img_index} on page {page_num}: {e}")
     
-    async def _extract_tables(self, page: fitz.Page, page_num: int, pdf_path: Path):
+    def _extract_tables(self, page: fitz.Page, page_num: int, pdf_path: Path):
         """Extract table elements."""
         
         # Simple table detection based on text layout
@@ -332,7 +331,7 @@ class ScientificPDFProcessor:
                     table_element.extract_table_data(pdf_path, page_num)
                     self.elements.append(table_element)
     
-    async def _create_contextual_chunks(self) -> List[Dict[str, Any]]:
+    def _create_contextual_chunks(self) -> List[Dict[str, Any]]:
         """Create contextual chunks that preserve document structure."""
         
         chunks = []

--- a/src/desktop_pdf_translator/rag/rag_chain.py
+++ b/src/desktop_pdf_translator/rag/rag_chain.py
@@ -2,12 +2,13 @@
 RAG chain that answers questions over indexed PDF documents.
 """
 
+import asyncio
 import logging
 from typing import List, Dict, Any, Optional
 import json
 from datetime import datetime
 
-from ..config import get_settings
+from ..config import TranslationService, get_settings
 from ..translators import TranslatorFactory
 from .vector_store import ChromaDBManager
 from .reference_manager import ReferenceManager
@@ -29,17 +30,36 @@ class EnhancedRAGChain:
         logger.info("RAG chain initialized")
 
     def _initialize_translator(self):
-        """Initialize the translator for answer generation."""
-        try:
-            preferred_service = self.settings.translation.preferred_service
-            self.translator = TranslatorFactory.create_translator(
-                service=preferred_service,
-                lang_in="auto",
-                lang_out="vi"
-            )
-            logger.info(f"Translator initialized: {preferred_service}")
-        except Exception as e:
-            logger.error(f"Failed to initialize translator: {e}")
+        """Initialize an LLM translator for answer generation.
+
+        Answer synthesis needs an instruction-following model, so Argos (the
+        default preferred_service) is never used here. Pick the preferred
+        service when it's an LLM with a key, otherwise the first LLM service
+        that has a key. With no key at all, stay on the template-answer path.
+        """
+        llm_services = (
+            TranslationService.OPENAI,
+            TranslationService.ANTHROPIC,
+            TranslationService.GEMINI,
+        )
+        preferred = self.settings.translation.preferred_service
+        candidates = [preferred] if preferred in llm_services else []
+        candidates += [s for s in llm_services if s not in candidates]
+
+        for service in candidates:
+            if not self.settings.has_api_key(service):
+                continue
+            try:
+                self.translator = TranslatorFactory.create_translator(
+                    service=service,
+                    lang_in="auto",
+                    lang_out="vi",
+                )
+                logger.info(f"RAG answer LLM initialized: {service.value}")
+                return
+            except Exception as e:
+                logger.error(f"Failed to initialize {service.value} for RAG: {e}")
+        logger.info("No LLM key configured — RAG will use template answers")
 
     async def answer_question(self, question: str, document_id: Optional[str] = None,
                             max_pdf_sources: int = 5,
@@ -148,22 +168,13 @@ Question: {question}
 
 Hypothetical answer:"""
 
-            if hasattr(self.translator, 'client') and hasattr(self.translator.client, 'chat'):
-                response = self.translator.client.chat.completions.create(
-                    model=self.translator.model,
-                    messages=[
-                        {"role": "system", "content": "You generate hypothetical answers for document retrieval."},
-                        {"role": "user", "content": hyde_prompt}
-                    ],
-                    max_tokens=150,
-                    temperature=0.3
-                )
-                return response.choices[0].message.content.strip()
-            elif hasattr(self.translator, 'model'):
-                response = self.translator.model.generate_content(hyde_prompt)
-                return response.text.strip()
-            else:
-                return question
+            answer = await asyncio.to_thread(
+                self.translator.generate,
+                hyde_prompt,
+                "You generate hypothetical answers for document retrieval.",
+                150,
+            )
+            return answer or question
 
         except Exception as e:
             logger.error(f"HyDE generation failed: {e}")
@@ -362,33 +373,20 @@ ANSWER:
         return prompt
 
     async def _generate_with_llm(self, prompt: str) -> str:
-        """Generate answer using LLM (OpenAI/Gemini)."""
-
-        try:
-            if hasattr(self.translator, 'client'):
-                # OpenAI-compatible
-                if hasattr(self.translator.client, 'chat'):
-                    response = self.translator.client.chat.completions.create(
-                        model=self.translator.model,
-                        messages=[
-                            {"role": "system", "content": "You are an intelligent AI assistant that answers questions based on documents. Always respond in Vietnamese regardless of the language of the question or source documents."},
-                            {"role": "user", "content": prompt}
-                        ],
-                        max_tokens=1000,
-                        temperature=0.3
-                    )
-                    return response.choices[0].message.content
-
-                # Gemini
-                elif hasattr(self.translator, 'model'):
-                    response = self.translator.model.generate_content(prompt)
-                    return response.text
-
-            return "Unable to generate answer with LLM."
-
-        except Exception as e:
-            logger.error(f"LLM generation failed: {e}")
-            raise
+        """Generate an answer with whichever LLM backend is configured."""
+        answer = await asyncio.to_thread(
+            self.translator.generate,
+            prompt,
+            (
+                "You are an intelligent AI assistant that answers questions "
+                "based on documents. Always respond in Vietnamese regardless "
+                "of the language of the question or source documents."
+            ),
+            1000,
+        )
+        if not answer:
+            raise RuntimeError("LLM returned no answer")
+        return answer
 
     def _generate_template_answer(self, question: str, pdf_sources: List[Dict[str, Any]]) -> str:
         """Generate template-based answer as fallback."""

--- a/src/desktop_pdf_translator/rag/vector_store.py
+++ b/src/desktop_pdf_translator/rag/vector_store.py
@@ -3,6 +3,7 @@ Vector store manager using ChromaDB for efficient similarity search.
 Handles embeddings, indexing, and retrieval for RAG system.
 """
 
+import asyncio
 import logging
 import os
 import json
@@ -226,11 +227,13 @@ class ChromaDBManager:
                 
                 metadatas.append(metadata)
             
-            # Add to collection
-            self.collection.add(
+            # Add to collection. Embedding + upsert are CPU-heavy and blocking;
+            # run off the event loop so the sidecar stays responsive.
+            await asyncio.to_thread(
+                self.collection.add,
                 ids=ids,
                 documents=documents,
-                metadatas=metadatas
+                metadatas=metadatas,
             )
             
             logger.info(f"Added {len(chunks)} chunks for document {document_id}")
@@ -254,12 +257,13 @@ class ChromaDBManager:
             List of similar chunks with scores
         """
         try:
-            # Perform similarity search
-            results = self.collection.query(
+            # Perform similarity search (embeds the query — run off-loop)
+            results = await asyncio.to_thread(
+                self.collection.query,
                 query_texts=[query],
                 n_results=n_results,
                 where=filter_metadata,
-                include=['documents', 'metadatas', 'distances']
+                include=['documents', 'metadatas', 'distances'],
             )
             
             # Format results
@@ -293,11 +297,12 @@ class ChromaDBManager:
             List of chunks for the document
         """
         try:
-            results = self.collection.get(
+            results = await asyncio.to_thread(
+                self.collection.get,
                 where={"document_id": document_id},
-                include=['documents', 'metadatas']
+                include=['documents', 'metadatas'],
             )
-            
+
             formatted_results = []
             if results['documents']:
                 for i in range(len(results['documents'])):
@@ -307,7 +312,7 @@ class ChromaDBManager:
                         'chunk_id': results['ids'][i]
                     }
                     formatted_results.append(result)
-            
+
             # Sort by chunk index
             formatted_results.sort(key=lambda x: x['metadata'].get('chunk_index', 0))
             
@@ -333,9 +338,10 @@ class ChromaDBManager:
         """
         try:
             # Get all chunks for the document
-            results = self.collection.get(
+            results = await asyncio.to_thread(
+                self.collection.get,
                 where={"document_id": document_id},
-                include=['documents', 'metadatas']
+                include=['documents', 'metadatas'],
             )
 
             formatted_results = []
@@ -385,14 +391,17 @@ class ChromaDBManager:
             True if successful
         """
         try:
-            # Get all chunk IDs for the document
-            results = self.collection.get(
+            # Get all chunk IDs for the document. NOTE: ids are always
+            # returned by get(); 'ids' is not a valid `include` value and
+            # passing it raises, which made this method always fail.
+            results = await asyncio.to_thread(
+                self.collection.get,
                 where={"document_id": document_id},
-                include=['ids']
+                include=[],
             )
-            
+
             if results['ids']:
-                self.collection.delete(ids=results['ids'])
+                await asyncio.to_thread(self.collection.delete, ids=results['ids'])
                 logger.info(f"Deleted {len(results['ids'])} chunks for document {document_id}")
             
             return True

--- a/src/desktop_pdf_translator/translators/anthropic_translator.py
+++ b/src/desktop_pdf_translator/translators/anthropic_translator.py
@@ -27,8 +27,6 @@ class AnthropicTranslator(BaseTranslator):
     Claude Opus / Sonnet / Haiku 4.x model families.
     """
 
-    min_request_interval = 1.0
-
     def __init__(self, lang_in: str, lang_out: str, **kwargs):
         super().__init__(lang_in, lang_out, **kwargs)
 
@@ -62,8 +60,6 @@ class AnthropicTranslator(BaseTranslator):
                 self._fire_paragraph_callback(processed_text, cached)
                 return cached
 
-            self._apply_rate_limiting()
-
             system_prompt, user_prompt = self._create_translation_prompt(processed_text)
 
             response = self.client.messages.create(
@@ -90,6 +86,35 @@ class AnthropicTranslator(BaseTranslator):
 
         except Exception as e:
             return self._handle_translation_error(e, text)
+
+    def generate(
+        self,
+        prompt: str,
+        system: str | None = None,
+        max_tokens: int = 1000,
+    ) -> str | None:
+        """Freeform generation used by the RAG chain."""
+        try:
+            kwargs = {}
+            if system:
+                kwargs["system"] = system
+            response = self.client.messages.create(
+                model=self.model,
+                max_tokens=max_tokens,
+                temperature=0.3,
+                messages=[{"role": "user", "content": prompt}],
+                timeout=60,
+                **kwargs,
+            )
+            text = "".join(
+                block.text
+                for block in response.content
+                if getattr(block, "type", None) == "text"
+            ).strip()
+            return text or None
+        except Exception as e:
+            logger.error(f"Anthropic generate failed: {e}")
+            return None
 
     def _create_translation_prompt(self, text: str) -> tuple[str, str]:
         source_lang = LANGUAGE_DISPLAY_NAMES.get(self.lang_in, self.lang_in)

--- a/src/desktop_pdf_translator/translators/base.py
+++ b/src/desktop_pdf_translator/translators/base.py
@@ -4,7 +4,6 @@ Base translator interface compatible with BabelDOC.
 
 import logging
 import re
-import time
 from abc import ABC, abstractmethod
 from typing import Dict, Optional, Any
 
@@ -34,8 +33,6 @@ class BaseTranslator(ABC):
     - Must support language attributes: lang_in, lang_out
     """
 
-    min_request_interval: float = 0.0
-
     def __init__(self, lang_in: str, lang_out: str, **kwargs):
         """Initialize translator with language configuration.
 
@@ -53,7 +50,6 @@ class BaseTranslator(ABC):
         self.lang_in = self._normalize_language_code(lang_in)
         self.lang_out = self._normalize_language_code(lang_out)
         self.translate_call_count = 0
-        self._last_request_time = 0.0
 
         # Pop the cross-cutting callback before passing the rest to the
         # subclass setup so backends don't need to thread it through their
@@ -113,7 +109,22 @@ class BaseTranslator(ABC):
             Translated text
         """
         pass
-    
+
+    def generate(
+        self,
+        prompt: str,
+        system: Optional[str] = None,
+        max_tokens: int = 1000,
+    ) -> Optional[str]:
+        """Freeform text generation for RAG answer synthesis.
+
+        LLM backends override this. The base implementation returns None,
+        meaning the backend (e.g. Argos NMT) cannot follow instructions —
+        callers must fall back to a non-LLM path.
+        """
+        return None
+
+
     def get_formular_placeholder(self, placeholder_id: int) -> tuple[str, str]:
         """
         Get formula placeholder for protecting math content.
@@ -149,16 +160,11 @@ class BaseTranslator(ABC):
             Text with restored formula
         """
         placeholder, regex_pattern = self.get_formular_placeholder(placeholder_id)
-        return re.sub(regex_pattern, original_formula, text, flags=re.IGNORECASE)
-    
-    def _apply_rate_limiting(self) -> None:
-        """Sleep so consecutive requests are spaced by `min_request_interval`."""
-        if self.min_request_interval <= 0:
-            return
-        elapsed = time.time() - self._last_request_time
-        if elapsed < self.min_request_interval:
-            time.sleep(self.min_request_interval - elapsed)
-        self._last_request_time = time.time()
+        # The formula is literal text, not a regex replacement template — a
+        # lambda keeps backslashes/`\1` in it from being interpreted by re.sub.
+        return re.sub(
+            regex_pattern, lambda _m: original_formula, text, flags=re.IGNORECASE
+        )
 
     def _preprocess_text(self, text: str) -> str:
         """Preprocess text before translation."""
@@ -178,9 +184,14 @@ class BaseTranslator(ABC):
 
         if self.lang_out == "vi":
             text = re.sub(r'\s+([.,;:!?])', r'\1', text)
-            text = re.sub(r'([.,;:!?])([^\s])', r'\1 \2', text)
-            text = text.replace("  ", " ")
-            text = text.replace('"', '"').replace('"', '"')
+            # Insert a space after punctuation only at genuine word boundaries.
+            # `,;:` → only when followed by a letter, so `1,000`, `12:30`,
+            # and `http://` stay intact. Sentence enders `.!?` → only before
+            # an uppercase letter (sentence boundary), so `3.14`,
+            # `example.com`, and `?a=1` query strings stay intact.
+            text = re.sub(r'([,;:])(?=[^\W\d_])', r'\1 ', text)
+            text = re.sub(r'([.!?])(?=[A-Z])', r'\1 ', text)
+            text = re.sub(r' {2,}', ' ', text)
 
         return text
     

--- a/src/desktop_pdf_translator/translators/gemini_translator.py
+++ b/src/desktop_pdf_translator/translators/gemini_translator.py
@@ -23,8 +23,6 @@ class GeminiTranslator(BaseTranslator):
     for Vietnamese language translations.
     """
 
-    min_request_interval = 2.0
-
     def __init__(self, lang_in: str, lang_out: str, **kwargs):
         super().__init__(lang_in, lang_out, **kwargs)
 
@@ -64,8 +62,6 @@ class GeminiTranslator(BaseTranslator):
                 self._fire_paragraph_callback(processed_text, cached)
                 return cached
 
-            self._apply_rate_limiting()
-
             response = self.client.models.generate_content(
                 model=self.model_name,
                 contents=self._create_translation_prompt(processed_text),
@@ -85,6 +81,30 @@ class GeminiTranslator(BaseTranslator):
 
         except Exception as e:
             return self._handle_translation_error(e, text)
+
+    def generate(
+        self,
+        prompt: str,
+        system: Optional[str] = None,
+        max_tokens: int = 1000,
+    ) -> Optional[str]:
+        """Freeform generation used by the RAG chain."""
+        try:
+            config = genai_types.GenerateContentConfig(
+                temperature=0.3,
+                max_output_tokens=max_tokens,
+                system_instruction=system if system else None,
+            )
+            response = self.client.models.generate_content(
+                model=self.model_name,
+                contents=prompt,
+                config=config,
+            )
+            text = response.text
+            return text.strip() if text else None
+        except Exception as e:
+            logger.error(f"Gemini generate failed: {e}")
+            return None
 
     def _create_translation_prompt(self, text: str) -> str:
         """Create optimized translation prompt for Vietnamese."""

--- a/src/desktop_pdf_translator/translators/openai_translator.py
+++ b/src/desktop_pdf_translator/translators/openai_translator.py
@@ -22,8 +22,6 @@ class OpenAITranslator(BaseTranslator):
     for Vietnamese language translations.
     """
 
-    min_request_interval = 1.0
-
     def __init__(self, lang_in: str, lang_out: str, **kwargs):
         super().__init__(lang_in, lang_out, **kwargs)
 
@@ -54,8 +52,6 @@ class OpenAITranslator(BaseTranslator):
                 self._fire_paragraph_callback(processed_text, cached)
                 return cached
 
-            self._apply_rate_limiting()
-
             response = self.client.chat.completions.create(
                 model=self.model,
                 messages=self._create_translation_prompt(processed_text),
@@ -71,6 +67,31 @@ class OpenAITranslator(BaseTranslator):
 
         except Exception as e:
             return self._handle_translation_error(e, text)
+
+    def generate(
+        self,
+        prompt: str,
+        system: Optional[str] = None,
+        max_tokens: int = 1000,
+    ) -> Optional[str]:
+        """Freeform generation used by the RAG chain."""
+        try:
+            messages: List[Dict[str, str]] = []
+            if system:
+                messages.append({"role": "system", "content": system})
+            messages.append({"role": "user", "content": prompt})
+            response = self.client.chat.completions.create(
+                model=self.model,
+                messages=messages,
+                max_tokens=max_tokens,
+                temperature=0.3,
+                timeout=60,
+            )
+            content = response.choices[0].message.content
+            return content.strip() if content else None
+        except Exception as e:
+            logger.error(f"OpenAI generate failed: {e}")
+            return None
 
     def _create_translation_prompt(self, text: str) -> List[Dict[str, str]]:
         """Create optimized translation prompt for Vietnamese."""

--- a/src/desktop_pdf_translator/translators/translation_cache.py
+++ b/src/desktop_pdf_translator/translators/translation_cache.py
@@ -212,6 +212,57 @@ class TranslationCache:
             logger.warning("clear_expired failed: %s", e)
             return 0
 
+    def enforce_size_cap(self) -> int:
+        """Delete oldest entries until the DB file is under `max_size_mb`.
+
+        The cap was previously declared but never enforced, so the cache grew
+        without bound (TTL expiry only marks rows; nothing reaped them
+        automatically). Deletes in oldest-first batches down to ~90% of the
+        cap, then VACUUMs to actually return the disk space. Returns the
+        number of rows removed.
+        """
+        try:
+            cap_bytes = int(self.max_size_mb * 1024 * 1024)
+            if not self.db_path.exists():
+                return 0
+            conn = self._conn()
+            # Fold the WAL into the main file first so st_size reflects the
+            # real on-disk footprint (in WAL mode the main file only shrinks
+            # after a checkpoint).
+            with self._write_lock:
+                conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            if self.db_path.stat().st_size <= cap_bytes:
+                return 0
+            total_rows = conn.execute("SELECT COUNT(*) FROM translations").fetchone()[0]
+            if total_rows == 0:
+                return 0
+            size = self.db_path.stat().st_size
+            target_bytes = int(cap_bytes * 0.9)
+            avg_row = max(1, size // total_rows)
+            rows_to_remove = min(
+                total_rows, -(-(size - target_bytes) // avg_row)  # ceil div
+            )
+            with self._write_lock:
+                cur = conn.execute(
+                    "DELETE FROM translations WHERE cache_key IN ("
+                    "  SELECT cache_key FROM translations"
+                    "  ORDER BY COALESCE(last_used, cached_at) ASC LIMIT ?"
+                    ")",
+                    (rows_to_remove,),
+                )
+                conn.commit()
+                conn.execute("VACUUM")
+                conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            removed = cur.rowcount
+            if removed:
+                logger.info(
+                    "Translation cache size cap: removed %d oldest entries", removed
+                )
+            return removed
+        except Exception as e:
+            logger.warning("enforce_size_cap failed: %s", e)
+            return 0
+
     def clear_all(self) -> int:
         try:
             conn = self._conn()


### PR DESCRIPTION
RAG:
- Answer generation only worked with OpenAI; Anthropic/Gemini/Argos hit AttributeError or a dead branch and silently fell back to template answers. Translators now expose generate(); the chain picks the first LLM service with a configured key instead of blindly using preferred_service (Argos by default).
- delete_document always 404'd: 'ids' is not a valid ChromaDB include value, so the lookup raised and the route mapped it to 404.
- The whole RAG stack (SentenceTransformer load, chroma add/query/get, fitz/camelot extraction, LLM calls) ran blocking on the event loop, stalling every endpoint during indexing/asking. Now offloaded via asyncio.to_thread; document_processor de-asynced (it awaited nothing).

Translators:
- Vietnamese post-processing regex inserted a space after every punctuation char, corrupting decimals (3.14 -> 3. 14), thousands separators, and URLs. Now letter/uppercase-aware.
- restore_formular_placeholder passed the formula as a regex replacement template; backslashes in it corrupted output or raised re.error.
- Removed per-instance rate limiting: racy across BabelDOC worker threads and redundant with BabelDOC's qps throttle.

Processor:
- Overlapping translation jobs could rmtree each other's active temp output dir; dirs now ownership-tracked with deferred cleanup.
- Zero-page PDF no longer divides by zero (validation rejects it).
- Rolling-PDF rebuild moved off the event loop.
- Removed dead cancel_processing/_current_task/get_session_info.

API/config:
- Prewarm no longer marks failed warm-ups as warm, and concurrent prewarm calls no longer double-schedule.
- DELETE /config/cache gains target=paragraph|pdf|all; the whole-PDF cache was previously unclearable. Settings "Clear all" clears both.
- Paragraph cache size cap is now actually enforced (startup GC reaps expired rows and LRU-evicts to the cap; needs WAL checkpoint for the file to shrink).
- pyproject.toml declared google-generativeai but the code imports the google-genai SDK; pip install -e . produced a broken install.

Shell/frontend:
- Tauri READY-wait could hang forever on a silent-but-alive sidecar; the 30s deadline is now a select branch.
- Job hooks flip to error when the SSE stream ends without a terminal event (sidecar crash) instead of showing "running" forever.