### PR TITLE
fix: honor the toolbar's source/target language selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,10 +147,10 @@ All routes (except `GET /health`) require `Authorization: Bearer <token>`.
 | GET | `/config` | Current settings (API keys masked) |
 | PUT | `/config` | Update API keys / models / language defaults |
 | POST | `/config/validate` | Test a key by spinning up a translator + calling its `validate_configuration()` |
-| GET | `/config/options` | Static dropdown data (languages, services, models) |
+| GET | `/config/options` | Static dropdown data (languages, services, models) + `supported_pairs` per service (`null` = unrestricted) |
 | GET | `/config/cache` | Paragraph-cache stats (entries, hit rate, size) |
 | DELETE | `/config/cache?scope=all\|expired` | Clear/GC the paragraph-level translation cache |
-| POST | `/translate` | Start translation job → returns `{ job_id }`. Body field `bypass_cache: bool` forces a full re-translate (used by the "Re-translate" button) |
+| POST | `/translate` | Start translation job → returns `{ job_id }`. `source_lang` / `target_lang` / `service` are `None`-defaulted (config applies); an unsupported pair is refused with **422** before the job is created. `bypass_cache: bool` forces a full re-translate (used by the "Re-translate" button) |
 | GET | `/translate/{job_id}/events` | SSE: `progress`, `done`, `error`, `cancelled` |
 | POST | `/translate/{job_id}/cancel` | Cancel an in-flight translation |
 | POST | `/rag/index` | Index a PDF into ChromaDB → returns `{ job_id }` |
@@ -224,18 +224,51 @@ Three non-obvious invariants in this area, each with a test:
    filename (`chapter_vi.pdf` is a Roman numeral) and manufactures exactly that
    collision.
 
-> **Pre-existing gap, deliberately not fixed here:** the ContextBar's
-> target-language `Select` writes `default_target_lang` to config, but
-> `useTranslation.start()` never sends `target_lang`, and
-> `TranslateRequest.target_lang` defaults to Vietnamese — so `process_pdf`'s
-> `target_lang or settings…` fallback never fires and output is *always*
-> Vietnamese. Rather than mirror that guess in the frontend, `CompletionEvent`
-> carries `target_lang` (the language `process_pdf` actually resolved) and the
-> store's `translationTargetLang` records what the producer reported, so the
-> Save dialog can't name a Vietnamese file `_ja.pdf` and wiring the selector
-> through later needs no frontend change. That wiring is its own fix: Argos is
-> en→vi only, so sending another language turns a silently-ignored setting into
-> a hard error.
+### Language selection and backend capabilities
+
+The toolbar's From/To selection reaches the pipeline through the request body,
+not through config. `useTranslation.start()` sends `source_lang` / `target_lang`
+/ `service` explicitly (built by `lib/translate-request.ts`), because
+`ContextBar`'s `update.mutate` is async: a Translate click landing before that
+PUT would otherwise run the *previous* selection. `CompletionEvent.target_lang`
+still reports the language `process_pdf` actually resolved, and the store's
+`translationTargetLang` records it, so the Save dialog names the file after what
+was produced rather than what was asked for.
+
+**`None` is the only way to say "unspecified".** `TranslateRequest` /
+`PrewarmRequest` default both language fields to `None`; the configured default
+is applied in exactly one place,
+`translators/capabilities.py:resolve_languages`. Restoring a non-null default
+on those fields (`LanguageCode.AUTO` / `VIETNAMESE`) is what caused issue #12 —
+both sentinels are truthy, so `process_pdf`'s `source_lang or settings…`
+fallback became dead code and every run produced Vietnamese. `AUTO` is a real,
+user-selectable source language, never a stand-in for "not chosen".
+
+**`translators/capabilities.py` is the single source of truth** for which
+requests can run, and is kept free of heavyweight imports (no BabelDOC, no
+torch, no SDK clients) so the API layer and tests can consult it cheaply:
+
+- `SUPPORTED_PAIRS` — `None` means unrestricted (the LLMs prompt for any target
+  via `LANGUAGE_DISPLAY_NAMES`); a `set` is exhaustive. Argos declares
+  `{("en","vi")}` and `argos_translator.py` reads its own `_SUPPORTED_PAIRS`
+  from here, so a request cannot be accepted as valid and then rejected mid-run.
+- `resolve_effective_service` — the "LLM with no API key silently becomes
+  Argos" rule, previously duplicated in `PDFProcessor` and the prewarm route.
+- `POST /translate` pre-flights the pair and returns **422** before creating the
+  job, checked against the *effective* service. Without this, honoring the
+  target language would trade a silent wrong-output for a `ValueError` raised
+  minutes into a run, from inside `translate()`, with a partial artifact on disk.
+- `GET /config/options` exposes `supported_pairs` per service, with auto-source
+  aliases already expanded, so the toolbar greys out unreachable targets without
+  reimplementing the matrix in TypeScript.
+
+Two consequences worth remembering: the frontend sends the **requested** service
+(not the effective one) so the sidecar still emits its "falling back to Argos"
+notice; and a disabled Radix `SelectItem` sets `pointer-events: none`, so the
+"why" is rendered as inline text plus a footer note, never a hover tooltip.
+
+Broadening Argos beyond en→vi means shipping more language packs, not editing
+`SUPPORTED_PAIRS` alone.
 
 ### Two-tier translation caching
 
@@ -245,9 +278,11 @@ process-wide singletons, and are content-addressed by SHA-256 — so neither is
 invalidated by re-runs with identical inputs.
 
 1. **Whole-PDF cache** (`processors/pdf_cache.py`, `get_pdf_cache()`). Keyed on
-   `sha256(file_bytes) | lang_out | service | model | PIPELINE_VERSION`
-   (**source language is deliberately excluded** — see the comment at
-   `_make_cache_key`). A hit lets `process_pdf` **skip the entire BabelDOC
+   `sha256(file_bytes) | lang_in | lang_out | service | model | PIPELINE_VERSION`.
+   Source language *was* excluded, on the premise that it never changes output;
+   that only held while the API pinned every request to `auto`. The LLM system
+   prompts name the source explicitly, so `auto` and `en` must not collide —
+   see the comment at `_make_cache_key`. A hit lets `process_pdf` **skip the entire BabelDOC
    pipeline**, copy the cached PDF into the live output dir, and emit synthetic
    SSE `progress`/`done` events. LRU-evicted to `pdf_cache_max_size_mb` (default
    1000 MB). Bump `PIPELINE_VERSION` when any BabelDOC config field that changes
@@ -376,24 +411,31 @@ Application logs are written to `~/AppData/Local/PDFusion/logs/app.log`.
 
 ## Tests and code quality
 
-- **Test coverage is narrow — only the PDF-export path is covered.** There is no
-  suite for the translation pipeline, RAG, config, or the caches; if you touch
-  those, expect to write tests from scratch.
+- **Test coverage is narrow — the PDF-export path and the language contract.**
+  There is still no suite for the translation pipeline proper, RAG, config, or
+  the cache *storage* layer; if you touch those, expect to write tests from
+  scratch.
 
   ```bash
   # Python (pytest config lives in pyproject.toml; tests/conftest.py puts src/ on sys.path)
-  python -m pytest tests           # tests/test_file_export.py, tests/test_pdf_export_api.py
+  python -m pytest tests           # test_file_export.py, test_pdf_export_api.py,
+                                   # test_translate_language_contract.py
 
   # Frontend (vitest, node environment — no jsdom)
   cd desktop && pnpm test          # src/**/*.test.ts
   ```
 
-  `tests/test_pdf_export_api.py` mounts `routes/pdf.py`'s router on a bare
-  `FastAPI()` rather than calling `create_app()`, because the full app imports
-  `routes/translation.py` → BabelDOC → torch, which turns a sub-second run into
-  a minute-long one. The frontend suite runs in the `node` environment: the
-  logic under test takes its Tauri/sidecar collaborators as arguments
-  (`lib/export-pdf.ts`), so no DOM or testing-library is needed.
+  Both Python suites avoid importing `routes/translation.py` → BabelDOC →
+  torch, which turns a sub-second run into a minute-long one:
+  `test_pdf_export_api.py` mounts `routes/pdf.py`'s router on a bare
+  `FastAPI()` instead of calling `create_app()`, and
+  `test_translate_language_contract.py` sticks to `api/schemas.py`,
+  `translators/capabilities.py` and `processors/pdf_cache.py` — all pure
+  decisions, so nothing is lost by staying out of the heavy modules. Keep new
+  tests on that side of the line where you can. The frontend suite runs in the
+  `node` environment: the logic under test takes its Tauri/sidecar
+  collaborators as arguments (`lib/export-pdf.ts`) or is pure
+  (`lib/translate-request.ts`), so no DOM or testing-library is needed.
 - **Python lint/format** tools are declared in `pyproject.toml [project.optional-dependencies].dev` (black line-length 88, isort with black profile, flake8, mypy) but the project has **no** pre-commit, no Makefile, and no CI. Run them manually if you want: `black src/ && isort src/`.
 - **TypeScript** is checked by `pnpm build` (which runs `tsc` before `vite build`). There is no separate lint step (no ESLint config).
 - **No CI**: `.github/workflows/` does not exist. All checks are local.
@@ -404,7 +446,10 @@ Application logs are written to `~/AppData/Local/PDFusion/logs/app.log`.
 - **Code signing** for Windows (SmartScreen will warn on first install of the unsigned `.msi`).
 - **CSP tightening** — `tauri.conf.json` still has `"csp": null`.
 - **Cross-platform** (macOS/Linux) — Tauri supports both, but explicit testing deferred. The PyInstaller spec is Windows-tested only.
-- **i18n of the UI strings** (the UI itself stays English; only the translation *output* is Vietnamese).
+- **i18n of the UI strings** (the UI itself stays English; the translation *output* follows the toolbar's target language).
+- **More Argos language pairs** — the offline backend ships en→vi only. Adding
+  a pair means shipping/downloading its pack, then extending `SUPPORTED_PAIRS`
+  in `translators/capabilities.py`.
 - **Pre-bundled ML assets** (HuggingFace embedding model + Argos en→vi pack) — currently both download on first use. Bundle them later for true offline-first.
 - **Auto-save preference** — saving a translation is an explicit action (Save dialog). A "always save `<name>_vi.pdf` beside the source" setting was proposed in issue #11 but deliberately not built: it needs a config field, a Settings control, and an overwrite policy for repeat runs.
 

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { toast } from "sonner";
@@ -13,6 +13,7 @@ import { StartupScreen } from "@/components/StartupScreen";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { useConfig } from "@/hooks/useConfig";
 import { useSidecar } from "@/hooks/useSidecar";
 import { isTranslationBusy, useTranslation } from "@/hooks/useTranslation";
 import { useAppStore } from "@/lib/store";
@@ -58,6 +59,25 @@ function Workspace() {
   const setExportedPath = useAppStore((s) => s.setExportedPdfPath);
   const originalPath = useAppStore((s) => s.originalPdfPath);
   const translation = useTranslation();
+  const { data: config } = useConfig();
+
+  // The toolbar persists its dropdowns to config, but that PUT is async — a
+  // Translate click can land first. Read the selection here and send it with
+  // the request so the run can't use a stale one.
+  // Deliberately the *requested* service, not the effective one: the sidecar
+  // does its own no-key fallback and emits the "falling back to Argos" notice
+  // the user sees as a toast. Pre-resolving it here would silence that.
+  const selection = useMemo(
+    () =>
+      config
+        ? {
+            sourceLang: config.translation.default_source_lang,
+            targetLang: config.translation.default_target_lang,
+            service: config.translation.preferred_service,
+          }
+        : {},
+    [config],
+  );
 
   const handlePickFile = useCallback(async () => {
     try {
@@ -75,26 +95,34 @@ function Workspace() {
         translation.reset();
         // Fire-and-forget pre-warm: by the time the user clicks Translate, the
         // Argos pack should be installed (or the LLM client should be live).
-        // Errors are intentionally swallowed — this is a UX optimization,
-        // never a correctness gate.
-        void api.post("/translate/prewarm", {}).catch(() => undefined);
+        // Carries the current selection — an empty body warms the configured
+        // default, which is the wrong backend once the user has changed the
+        // dropdowns. Errors are intentionally swallowed: this is a UX
+        // optimization, never a correctness gate.
+        void api
+          .post("/translate/prewarm", {
+            source_lang: selection.sourceLang,
+            target_lang: selection.targetLang,
+            service: selection.service,
+          })
+          .catch(() => undefined);
       }
     } catch (e) {
       toast.error("Could not open file picker", {
         description: (e as Error).message,
       });
     }
-  }, [setOriginalPath, setTranslatedPath, setExportedPath, translation]);
+  }, [setOriginalPath, setTranslatedPath, setExportedPath, translation, selection]);
 
   const handleTranslate = useCallback(() => {
     if (!originalPath) return;
-    void translation.start(originalPath);
-  }, [originalPath, translation]);
+    void translation.start(originalPath, selection);
+  }, [originalPath, translation, selection]);
 
   const handleReTranslate = useCallback(() => {
     if (!originalPath) return;
-    void translation.start(originalPath, { bypassCache: true });
-  }, [originalPath, translation]);
+    void translation.start(originalPath, { ...selection, bypassCache: true });
+  }, [originalPath, translation, selection]);
 
   return (
     <div className="flex h-full w-full flex-col bg-background text-foreground">

--- a/desktop/src/components/layout/ContextBar.tsx
+++ b/desktop/src/components/layout/ContextBar.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight, FilePlus, Loader2, MessageSquare, RefreshCw, Sparkles } from "lucide-react";
+import { ArrowRight, FilePlus, Loader2, Lock, MessageSquare, RefreshCw, Sparkles } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -18,11 +18,19 @@ import {
 import { useConfig, useOptions, useUpdateConfig } from "@/hooks/useConfig";
 import { api } from "@/lib/api-client";
 import { basename } from "@/lib/export-pdf";
+import { effectiveService, isPairSupported } from "@/lib/translate-request";
 import { useAppStore } from "@/lib/store";
 import { cn } from "@/lib/utils";
 
-function prewarm() {
-  void api.post("/translate/prewarm", {}).catch(() => undefined);
+/** Warm the backend the user just selected. The value is passed in rather than
+ *  read back from config: `update.mutate` hasn't round-tripped yet, so config
+ *  still holds the *previous* selection at this point. */
+function prewarm(selection: {
+  source_lang?: string;
+  target_lang?: string;
+  service?: string;
+}) {
+  void api.post("/translate/prewarm", selection).catch(() => undefined);
 }
 
 interface ContextBarProps {
@@ -62,6 +70,19 @@ export function ContextBar({
     ? config?.[service].model ?? activeService.models[0]
     : "";
 
+  // Which targets the backend that will *actually* run can reach. An LLM with
+  // no API key is silently downgraded to Argos by the sidecar, so this asks
+  // about the effective service — offering Japanese under a keyless "OpenAI"
+  // selection would produce a job the sidecar refuses.
+  const targetSupported = (code: string) =>
+    !config || !options
+      ? true
+      : isPairSupported(options, effectiveService(config), sourceLang, code);
+
+  const hasLockedTarget = !!options?.languages.some(
+    (l) => l.code !== "auto" && !targetSupported(l.code),
+  );
+
   const ready = config && options;
   const canTranslate = !!originalPath && !translating && ready;
 
@@ -91,7 +112,7 @@ export function ContextBar({
           value={sourceLang}
           onValueChange={(v) => {
             update.mutate({ default_source_lang: v });
-            prewarm();
+            prewarm({ source_lang: v, target_lang: targetLang, service });
           }}
         >
           <SelectTrigger size="sm" className="h-8 min-w-[140px]">
@@ -110,7 +131,7 @@ export function ContextBar({
           value={targetLang}
           onValueChange={(v) => {
             update.mutate({ default_target_lang: v });
-            prewarm();
+            prewarm({ source_lang: sourceLang, target_lang: v, service });
           }}
         >
           <SelectTrigger size="sm" className="h-8 min-w-[140px]">
@@ -119,11 +140,33 @@ export function ContextBar({
           <SelectContent>
             {options?.languages
               .filter((l) => l.code !== "auto")
-              .map((l) => (
-                <SelectItem key={l.code} value={l.code}>
-                  {l.label}
-                </SelectItem>
-              ))}
+              .map((l) => {
+                const supported = targetSupported(l.code);
+                return (
+                  <SelectItem key={l.code} value={l.code} disabled={!supported}>
+                    <span className="flex items-center gap-1.5">
+                      {l.label}
+                      {!supported && (
+                        <>
+                          <Lock className="h-3 w-3" />
+                          <span className="text-[10px] text-muted-foreground">
+                            API key needed
+                          </span>
+                        </>
+                      )}
+                    </span>
+                  </SelectItem>
+                );
+              })}
+            {hasLockedTarget && (
+              // A disabled Radix item sets `pointer-events: none`, so a hover
+              // tooltip on the row can never fire. The explanation goes here
+              // instead, where it's visible without hovering anything.
+              <p className="mt-1 border-t border-border px-2 pt-2 text-[11px] leading-snug text-muted-foreground">
+                Offline Argos translates English → Vietnamese only. Add an API
+                key in Settings to translate to other languages.
+              </p>
+            )}
           </SelectContent>
         </Select>
       </div>
@@ -134,7 +177,7 @@ export function ContextBar({
         value={service}
         onValueChange={(v) => {
           update.mutate({ preferred_service: v as typeof service });
-          prewarm();
+          prewarm({ source_lang: sourceLang, target_lang: targetLang, service: v });
         }}
       >
         <SelectTrigger size="sm" className="h-8 min-w-[150px]">

--- a/desktop/src/hooks/useConfig.ts
+++ b/desktop/src/hooks/useConfig.ts
@@ -47,6 +47,10 @@ export interface ServiceOption {
   code: ServiceCode;
   label: string;
   models: string[];
+  /** `[source, target]` pairs this backend can produce, or `null` when it has
+   *  no restriction. Auto-source aliases are already expanded server-side —
+   *  see `translators/capabilities.py:supported_pairs_for`. */
+  supported_pairs: string[][] | null;
 }
 
 export interface OptionsResponse {

--- a/desktop/src/hooks/useTranslation.ts
+++ b/desktop/src/hooks/useTranslation.ts
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
-import { api } from "@/lib/api-client";
+import { ApiError, api } from "@/lib/api-client";
 import { streamEvents } from "@/lib/sse";
 import { useAppStore } from "@/lib/store";
+import { buildTranslateBody } from "@/lib/translate-request";
 
 interface ProgressUpdate {
   stage?: string;
@@ -104,6 +105,13 @@ function formatRelative(iso: string): string {
 export interface StartOptions {
   /** Skip the PDF-level cache for this run — forces a fresh translation. */
   bypassCache?: boolean;
+  /** The toolbar's current selection. Passed explicitly rather than left to
+   *  the sidecar's config lookup: changing a dropdown fires an async PUT, so a
+   *  Translate click landing before that PUT would otherwise run the *previous*
+   *  selection. Omitted values fall back to the configured defaults. */
+  sourceLang?: string | null;
+  targetLang?: string | null;
+  service?: string | null;
 }
 
 export function useTranslation() {
@@ -150,19 +158,30 @@ export function useTranslation() {
 
       let jobId: string;
       try {
-        const accepted = await api.post<{ job_id: string }>("/translate", {
-          file_path: filePath,
-          visible_page: visiblePage,
-          bypass_cache: opts.bypassCache ?? false,
-        });
+        const accepted = await api.post<{ job_id: string }>(
+          "/translate",
+          buildTranslateBody({
+            filePath,
+            visiblePage,
+            bypassCache: opts.bypassCache,
+            sourceLang: opts.sourceLang,
+            targetLang: opts.targetLang,
+            service: opts.service,
+          }),
+        );
         jobId = accepted.job_id;
         setActiveJob(jobId);
       } catch (e) {
-        setState({
-          ...INITIAL,
-          status: "error",
-          error: (e as Error).message,
-        });
+        // The sidecar pre-flights the language pair and answers 422 with a
+        // sentence meant for the user ("Argos translates English → Vietnamese
+        // only…"). Show that, not `ApiError`'s "422: " prefix.
+        const message = e instanceof ApiError ? e.detail : (e as Error).message;
+        if (e instanceof ApiError && e.status === 422) {
+          toast.error("Can't translate this combination", {
+            description: message,
+          });
+        }
+        setState({ ...INITIAL, status: "error", error: message });
         return;
       }
 

--- a/desktop/src/lib/translate-request.test.ts
+++ b/desktop/src/lib/translate-request.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildTranslateBody,
+  effectiveService,
+  isPairSupported,
+} from "./translate-request";
+import type { ConfigResponse, OptionsResponse } from "@/hooks/useConfig";
+
+const FILE = "D:\\Papers\\attention is all you need.pdf";
+
+/** `/config/options` as the sidecar sends it: Argos restricted, LLMs open. */
+const OPTIONS: Pick<OptionsResponse, "services"> = {
+  services: [
+    {
+      code: "argos",
+      label: "Argos Translate (offline)",
+      models: ["argostranslate"],
+      // auto-source alias already expanded server-side
+      supported_pairs: [
+        ["auto", "vi"],
+        ["en", "vi"],
+      ],
+    },
+    {
+      code: "openai",
+      label: "OpenAI",
+      models: ["gpt-4.1"],
+      supported_pairs: null,
+    },
+  ],
+};
+
+type ConfigSlice = Parameters<typeof effectiveService>[0];
+
+function config(
+  preferred: ConfigResponse["translation"]["preferred_service"],
+  keys: Partial<Record<"openai" | "gemini" | "anthropic", boolean>> = {},
+): ConfigSlice {
+  const service = (has_key: boolean) => ({ has_key, model: "m" });
+  return {
+    translation: { preferred_service: preferred } as ConfigSlice["translation"],
+    openai: service(keys.openai ?? false),
+    gemini: service(keys.gemini ?? false),
+    anthropic: service(keys.anthropic ?? false),
+    argos: service(false),
+  };
+}
+
+describe("buildTranslateBody", () => {
+  it("always carries the file, page and cache flag", () => {
+    expect(buildTranslateBody({ filePath: FILE, visiblePage: 3 })).toEqual({
+      file_path: FILE,
+      visible_page: 3,
+      bypass_cache: false,
+    });
+  });
+
+  it("sends the selected languages and service", () => {
+    expect(
+      buildTranslateBody({
+        filePath: FILE,
+        visiblePage: 1,
+        bypassCache: true,
+        sourceLang: "en",
+        targetLang: "ja",
+        service: "openai",
+      }),
+    ).toEqual({
+      file_path: FILE,
+      visible_page: 1,
+      bypass_cache: true,
+      source_lang: "en",
+      target_lang: "ja",
+      service: "openai",
+    });
+  });
+
+  // Regression guard for issue #12: an omitted language must stay omitted so
+  // the sidecar applies the configured default. Sending a placeholder here is
+  // exactly the bug — a non-null sentinel that pre-empts the real default.
+  it("omits unset languages rather than substituting a placeholder", () => {
+    const body = buildTranslateBody({
+      filePath: FILE,
+      visiblePage: 1,
+      sourceLang: null,
+      targetLang: undefined,
+    });
+    expect(body).not.toHaveProperty("source_lang");
+    expect(body).not.toHaveProperty("target_lang");
+    expect(body).not.toHaveProperty("service");
+  });
+});
+
+describe("effectiveService", () => {
+  it("keeps an LLM that has a key", () => {
+    expect(effectiveService(config("openai", { openai: true }))).toBe("openai");
+  });
+
+  // Mirrors the sidecar's silent downgrade. The toolbar can read "OpenAI"
+  // while every run is really Argos.
+  it("falls back to argos when the selected LLM has no key", () => {
+    expect(effectiveService(config("openai"))).toBe("argos");
+    expect(effectiveService(config("anthropic"))).toBe("argos");
+  });
+
+  it("leaves argos alone — it never needs a key", () => {
+    expect(effectiveService(config("argos"))).toBe("argos");
+  });
+});
+
+describe("isPairSupported", () => {
+  it("accepts the pair argos actually ships", () => {
+    expect(isPairSupported(OPTIONS, "argos", "en", "vi")).toBe(true);
+    expect(isPairSupported(OPTIONS, "argos", "auto", "vi")).toBe(true);
+  });
+
+  it("rejects targets argos has no pack for", () => {
+    expect(isPairSupported(OPTIONS, "argos", "en", "ja")).toBe(false);
+    expect(isPairSupported(OPTIONS, "argos", "en", "zh-cn")).toBe(false);
+  });
+
+  it("treats a null matrix as unrestricted", () => {
+    expect(isPairSupported(OPTIONS, "openai", "en", "ja")).toBe(true);
+    expect(isPairSupported(OPTIONS, "openai", "zh-tw", "vi")).toBe(true);
+  });
+
+  // A sidecar too old to send `supported_pairs` must not black out the whole
+  // dropdown — the server still pre-flights and answers 422.
+  it("treats an unknown service as unrestricted", () => {
+    expect(isPairSupported(OPTIONS, "gemini", "en", "ja")).toBe(true);
+  });
+});

--- a/desktop/src/lib/translate-request.ts
+++ b/desktop/src/lib/translate-request.ts
@@ -1,0 +1,86 @@
+/**
+ * Building a `/translate` request, and working out which language pairs the
+ * currently-selected backend can actually deliver.
+ *
+ * Split out of the hook and the toolbar for two reasons. It keeps the pure
+ * decisions unit-testable under the suite's `node` environment (same reason
+ * `export-pdf.ts` exists), and it puts the "which service will really run"
+ * question in one place — the toolbar needs it to grey out targets, and the
+ * translate call needs it to send the right thing.
+ *
+ * The capability data itself is *not* defined here: it arrives from
+ * `GET /config/options` as `supported_pairs`, already expanded server-side
+ * (see `translators/capabilities.py`). Duplicating the matrix in TypeScript is
+ * how the two sides drift apart.
+ */
+
+import type { ConfigResponse, OptionsResponse, ServiceCode } from "@/hooks/useConfig";
+
+export interface TranslateBodyInput {
+  filePath: string;
+  visiblePage: number;
+  bypassCache?: boolean;
+  /** Omitted from the body when null/undefined — the sidecar then applies the
+   *  configured default. Never send a placeholder like "auto" to mean "unset":
+   *  "auto" is a real, selectable source language. */
+  sourceLang?: string | null;
+  targetLang?: string | null;
+  service?: string | null;
+}
+
+export function buildTranslateBody(
+  input: TranslateBodyInput,
+): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    file_path: input.filePath,
+    visible_page: input.visiblePage,
+    bypass_cache: input.bypassCache ?? false,
+  };
+  if (input.sourceLang) body.source_lang = input.sourceLang;
+  if (input.targetLang) body.target_lang = input.targetLang;
+  if (input.service) body.service = input.service;
+  return body;
+}
+
+/**
+ * The service that will really run, mirroring
+ * `translators/capabilities.py:resolve_effective_service`.
+ *
+ * An LLM with no API key is silently downgraded to Argos by the sidecar, so a
+ * toolbar reading "OpenAI" can still be an Argos run — and Argos only does
+ * English → Vietnamese. Asking about the *requested* service here would offer
+ * the user Japanese and then fail the job.
+ */
+export function effectiveService(
+  config: Pick<ConfigResponse, "translation" | "openai" | "gemini" | "anthropic" | "argos">,
+): ServiceCode {
+  const requested = config.translation.preferred_service;
+  if (requested === "argos") return "argos";
+  return config[requested]?.has_key ? requested : "argos";
+}
+
+function supportedPairs(
+  options: Pick<OptionsResponse, "services">,
+  service: ServiceCode,
+): string[][] | null | undefined {
+  return options.services.find((s) => s.code === service)?.supported_pairs;
+}
+
+/**
+ * Whether `service` can translate this pair.
+ *
+ * `null` pairs mean unrestricted (the LLMs). An unknown service — or options
+ * from a sidecar too old to send `supported_pairs` — is treated as
+ * unrestricted too: the server still pre-flights the request and answers 422,
+ * so guessing "unsupported" here would only hide working combinations.
+ */
+export function isPairSupported(
+  options: Pick<OptionsResponse, "services">,
+  service: ServiceCode,
+  sourceLang: string,
+  targetLang: string,
+): boolean {
+  const pairs = supportedPairs(options, service);
+  if (pairs == null) return true;
+  return pairs.some(([from, to]) => from === sourceLang && to === targetLang);
+}

--- a/src/desktop_pdf_translator/api/routes/config.py
+++ b/src/desktop_pdf_translator/api/routes/config.py
@@ -13,6 +13,11 @@ from ...config import (
     get_settings,
 )
 from ...translators import TranslatorFactory, get_translation_cache
+from ...translators.capabilities import (
+    LANGUAGE_LABELS,
+    SERVICE_LABELS,
+    supported_pairs_for,
+)
 from ..auth import require_token
 from ..schemas import (
     APIKeyMaskedSettings,
@@ -160,32 +165,31 @@ async def validate_credentials(payload: ValidateRequest) -> ValidateResponse:
 # Static option lists (helpful for select dropdowns in the frontend)
 # ---------------------------------------------------------------------------
 
-_LANGUAGE_LABELS = {
-    LanguageCode.AUTO: "Auto-detect",
-    LanguageCode.VIETNAMESE: "Vietnamese",
-    LanguageCode.ENGLISH: "English",
-    LanguageCode.JAPANESE: "Japanese",
-    LanguageCode.CHINESE_SIMPLIFIED: "Chinese (Simplified)",
-    LanguageCode.CHINESE_TRADITIONAL: "Chinese (Traditional)",
-}
-
+# Labels come from the capability module so the dropdown and the "unsupported
+# pair" error message can never name the same language differently.
 _SERVICE_MODELS = {
-    TranslationService.ARGOS: ("Argos Translate (offline)", ["argostranslate"]),
-    TranslationService.OPENAI: ("OpenAI", ["gpt-4.1"]),
-    TranslationService.GEMINI: ("Google Gemini", ["gemini-1.5-flash"]),
-    TranslationService.ANTHROPIC: (
-        "Anthropic Claude",
-        ["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5-20251001"],
-    ),
+    TranslationService.ARGOS: ["argostranslate"],
+    TranslationService.OPENAI: ["gpt-4.1"],
+    TranslationService.GEMINI: ["gemini-1.5-flash"],
+    TranslationService.ANTHROPIC: [
+        "claude-opus-4-7",
+        "claude-sonnet-4-6",
+        "claude-haiku-4-5-20251001",
+    ],
 }
 
 
 @router.get("/options", response_model=OptionsResponse)
 async def get_options() -> OptionsResponse:
     return OptionsResponse(
-        languages=[LanguageOption(code=c.value, label=_LANGUAGE_LABELS[c]) for c in LanguageCode],
+        languages=[LanguageOption(code=c.value, label=LANGUAGE_LABELS[c]) for c in LanguageCode],
         services=[
-            ServiceOption(code=s.value, label=_SERVICE_MODELS[s][0], models=_SERVICE_MODELS[s][1])
+            ServiceOption(
+                code=s.value,
+                label=SERVICE_LABELS[s],
+                models=_SERVICE_MODELS[s],
+                supported_pairs=supported_pairs_for(s),
+            )
             for s in TranslationService
         ],
     )

--- a/src/desktop_pdf_translator/api/routes/translation.py
+++ b/src/desktop_pdf_translator/api/routes/translation.py
@@ -12,6 +12,10 @@ from ...config import TranslationService, get_settings
 from ...processors.events import EventType
 from ...processors.processor import PDFProcessor
 from ...translators import TranslatorFactory
+from ...translators.capabilities import (
+    resolve_effective_service,
+    resolve_languages,
+)
 from ..auth import require_token
 from ..jobs import get_registry, serialize_sse_event
 from ..schemas import (
@@ -202,12 +206,16 @@ def _warm_translator(
 @router.post("/prewarm", response_model=PrewarmResponse)
 async def prewarm(payload: PrewarmRequest) -> PrewarmResponse:
     settings = get_settings()
-    service = payload.service or settings.translation.preferred_service
-    # Soft-fallback to Argos when LLM has no key, matching processor logic.
-    if service != TranslationService.ARGOS and not settings.has_api_key(service):
-        service = TranslationService.ARGOS
+    service = resolve_effective_service(
+        settings, payload.service or settings.translation.preferred_service
+    )
+    # Unspecified languages mean "whatever is configured" — warming auto→vi
+    # while the toolbar says Japanese warms the wrong backend.
+    source_lang, target_lang = resolve_languages(
+        settings, payload.source_lang, payload.target_lang
+    )
 
-    key = (service.value, payload.source_lang.value, payload.target_lang.value)
+    key = (service.value, source_lang.value, target_lang.value)
     with _WARM_LOCK:
         already = key in _WARMED
         in_flight = key in _WARMING
@@ -232,8 +240,8 @@ async def prewarm(payload: PrewarmRequest) -> PrewarmResponse:
             ok, msg = await asyncio.to_thread(
                 _warm_translator,
                 service,
-                payload.source_lang.value,
-                payload.target_lang.value,
+                source_lang.value,
+                target_lang.value,
             )
         except Exception as exc:  # noqa: BLE001 — never leave key stuck in _WARMING
             ok, msg = False, f"Pre-warm crashed: {exc}"

--- a/src/desktop_pdf_translator/api/routes/translation.py
+++ b/src/desktop_pdf_translator/api/routes/translation.py
@@ -15,6 +15,7 @@ from ...translators import TranslatorFactory
 from ...translators.capabilities import (
     resolve_effective_service,
     resolve_languages,
+    unsupported_reason,
 )
 from ..auth import require_token
 from ..jobs import get_registry, serialize_sse_event
@@ -110,6 +111,26 @@ async def _run_translation(job_id: str, payload: TranslateRequest) -> None:
 async def start_translation(payload: TranslateRequest) -> JobAccepted:
     if not Path(payload.file_path).exists():
         raise HTTPException(status_code=400, detail=f"File not found: {payload.file_path}")
+
+    # Pre-flight the language pair before the job exists. Argos raises on an
+    # unsupported pair from inside translate(), which is minutes into a run —
+    # after file validation, translator setup and BabelDOC layout, with a
+    # partial artifact already on disk. Reject it here instead.
+    #
+    # Checked against the *effective* service: with no API key the request
+    # silently becomes an Argos run, so "OpenAI + Japanese" must be refused
+    # even though OpenAI itself could do it.
+    settings = get_settings()
+    source_lang, target_lang = resolve_languages(
+        settings, payload.source_lang, payload.target_lang
+    )
+    effective_service = resolve_effective_service(
+        settings, payload.service or settings.translation.preferred_service
+    )
+    reason = unsupported_reason(effective_service, source_lang, target_lang)
+    if reason:
+        raise HTTPException(status_code=422, detail=reason)
+
     registry = get_registry()
     job = await registry.create()
     job.task = asyncio.create_task(_run_translation(job.job_id, payload))

--- a/src/desktop_pdf_translator/api/schemas.py
+++ b/src/desktop_pdf_translator/api/schemas.py
@@ -201,6 +201,11 @@ class ServiceOption(BaseModel):
     code: str
     label: str
     models: List[str]
+    # Every (source, target) pair this backend can produce, or `None` for
+    # "unrestricted". Lets the toolbar grey out targets the selected backend
+    # can't reach instead of letting the user start a job that dies mid-run.
+    # Auto-source aliases are already expanded server-side.
+    supported_pairs: Optional[List[List[str]]] = None
 
 
 class OptionsResponse(BaseModel):

--- a/src/desktop_pdf_translator/api/schemas.py
+++ b/src/desktop_pdf_translator/api/schemas.py
@@ -82,8 +82,13 @@ class ValidateResponse(BaseModel):
 
 class TranslateRequest(BaseModel):
     file_path: str
-    source_lang: LanguageCode = LanguageCode.AUTO
-    target_lang: LanguageCode = LanguageCode.VIETNAMESE
+    # `None` means "unspecified" — the configured default applies. These were
+    # previously non-null sentinels (AUTO / VIETNAMESE), which made the config
+    # fallback in `processor.process_pdf` dead code and pinned every run to
+    # Vietnamese no matter what the toolbar said (issue #12). Defaults are
+    # resolved in exactly one place: `translators.capabilities.resolve_languages`.
+    source_lang: Optional[LanguageCode] = None
+    target_lang: Optional[LanguageCode] = None
     service: Optional[TranslationService] = None
     output_dir: Optional[str] = None
     visible_page: int = Field(1, ge=1, description="1-indexed page the viewer is currently showing; seeds the priority queue")
@@ -103,8 +108,10 @@ class PrewarmRequest(BaseModel):
     instantiates the SDK client so the first translate() call avoids cold-start."""
 
     service: Optional[TranslationService] = None
-    source_lang: LanguageCode = LanguageCode.AUTO
-    target_lang: LanguageCode = LanguageCode.VIETNAMESE
+    # Same "None means unspecified" contract as TranslateRequest — pre-warming
+    # auto→vi while the toolbar says Japanese warms the wrong backend.
+    source_lang: Optional[LanguageCode] = None
+    target_lang: Optional[LanguageCode] = None
 
 
 class PrewarmResponse(BaseModel):

--- a/src/desktop_pdf_translator/processors/pdf_cache.py
+++ b/src/desktop_pdf_translator/processors/pdf_cache.py
@@ -63,15 +63,21 @@ def _make_cache_key(
     model: Optional[str],
     pipeline_version: str,
 ) -> str:
-    # Source language deliberately excluded from the key. Output bytes for a
-    # given (file_hash, target_lang, service, model) are independent of what
-    # the user picked as `source_lang` — Argos forces auto→en, LLMs auto-
-    # detect from content, neither uses the source-lang hint to change output.
-    # Keying on it would create separate entries for "auto" vs "en" on the
-    # same English PDF and miss valid hits when the user switches the dropdown.
-    # `lang_in` accepted for API stability / debug logs only.
-    del lang_in  # noqa: F841 — intentionally unused
-    payload = f"{file_hash}|{lang_out}|{service}|{model or ''}|{pipeline_version}"
+    # Source language IS part of the key. It used to be excluded, on the
+    # premise that output bytes are independent of what the user picked as
+    # `source_lang`. That held only because the API pinned every request to
+    # `auto` (issue #12) — with the dropdown now reaching the pipeline, the
+    # LLM system prompts name the source explicitly
+    # (`LANGUAGE_DISPLAY_NAMES.get(self.lang_in)` in openai/gemini/anthropic
+    # translators), so "auto" and "en" can produce different bytes and must not
+    # collide on one entry.
+    #
+    # No PIPELINE_VERSION bump accompanies this: adding a field to the payload
+    # already changes every key, so pre-existing entries simply stop matching
+    # and get LRU-evicted.
+    payload = (
+        f"{file_hash}|{lang_in}|{lang_out}|{service}|{model or ''}|{pipeline_version}"
+    )
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 

--- a/src/desktop_pdf_translator/processors/processor.py
+++ b/src/desktop_pdf_translator/processors/processor.py
@@ -21,6 +21,7 @@ from babeldoc.format.pdf.translation_config import WatermarkOutputMode as BabelD
 from ..config import get_settings, FileMetadata, LanguageCode, TranslationService
 from ..translators import TranslatorFactory
 from ..translators.argos_translator import ArgosTranslator
+from ..translators.capabilities import resolve_effective_service, resolve_languages
 from .events import (
     ProcessingEvent,
     ProgressEvent,
@@ -234,8 +235,9 @@ class PDFProcessor:
 
         try:
             # Use provided languages or fallback to config
-            source_lang = source_lang or self.settings.translation.default_source_lang
-            target_lang = target_lang or self.settings.translation.default_target_lang
+            source_lang, target_lang = resolve_languages(
+                self.settings, source_lang, target_lang
+            )
             translation_service = translation_service or self.settings.translation.preferred_service
 
             # Soft-fallback: if the user picked an LLM service but didn't
@@ -621,18 +623,10 @@ class PDFProcessor:
     def _resolve_effective_service(
         self, requested: TranslationService
     ) -> TranslationService:
-        """Pick the service to actually use given current credentials.
-
-        Argos (offline) is always usable. For LLM services, fall back to Argos
-        when the user has no key configured. Matches the product rule:
-        "Argos is default; LLM wins when a key exists".
-        """
-        if self.settings.has_api_key(requested):
-            return requested
-        logger.info(
-            "No API key for %s — falling back to Argos for this run", requested
-        )
-        return TranslationService.ARGOS
+        """Thin wrapper over the shared rule in `translators.capabilities` —
+        kept so the API layer and the processor can never disagree about which
+        service a request will really run on."""
+        return resolve_effective_service(self.settings, requested)
 
     async def _validate_file(self, file_path: Path) -> FileMetadata:
         """Validate PDF file and extract metadata."""

--- a/src/desktop_pdf_translator/translators/argos_translator.py
+++ b/src/desktop_pdf_translator/translators/argos_translator.py
@@ -19,14 +19,18 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
+from ..config import TranslationService
 from .base import BaseTranslator
+from .capabilities import SUPPORTED_PAIRS
 from .translation_cache import llm_cache_get as _llm_cache_get, llm_cache_set as _llm_cache_set
 
 
 logger = logging.getLogger(__name__)
 
 
-_SUPPORTED_PAIRS = {("en", "vi")}
+# Declared once, in the capability matrix the API layer also consults, so a
+# request can't be accepted as valid and then rejected here mid-run.
+_SUPPORTED_PAIRS = SUPPORTED_PAIRS[TranslationService.ARGOS]
 
 # Upper bound on how long a single translate() caller will block waiting for its
 # batch to decode. Guards against a hang if a batch worker dies without firing

--- a/src/desktop_pdf_translator/translators/capabilities.py
+++ b/src/desktop_pdf_translator/translators/capabilities.py
@@ -21,11 +21,133 @@ Both now live here.
 from __future__ import annotations
 
 import logging
-from typing import Optional, Tuple
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 from ..config import LanguageCode, TranslationService
 
 logger = logging.getLogger(__name__)
+
+
+LangLike = Union[LanguageCode, str]
+
+
+# User-facing language names. Lives here rather than in the API layer so the
+# capability messages below and the `/config/options` dropdown data can't drift
+# apart.
+LANGUAGE_LABELS: Dict[LanguageCode, str] = {
+    LanguageCode.AUTO: "Auto-detect",
+    LanguageCode.VIETNAMESE: "Vietnamese",
+    LanguageCode.ENGLISH: "English",
+    LanguageCode.JAPANESE: "Japanese",
+    LanguageCode.CHINESE_SIMPLIFIED: "Chinese (Simplified)",
+    LanguageCode.CHINESE_TRADITIONAL: "Chinese (Traditional)",
+}
+
+SERVICE_LABELS: Dict[TranslationService, str] = {
+    TranslationService.ARGOS: "Argos Translate (offline)",
+    TranslationService.OPENAI: "OpenAI",
+    TranslationService.GEMINI: "Google Gemini",
+    TranslationService.ANTHROPIC: "Anthropic Claude",
+}
+
+
+# Which (source, target) pairs each backend can actually produce.
+#
+#   None      → no restriction; the backend handles any pair we expose.
+#   set[...]  → exhaustive. Anything outside it fails.
+#
+# The LLMs prompt for an arbitrary target language (see LANGUAGE_DISPLAY_NAMES
+# in base.py), so they are unrestricted. Argos is an NMT model with one
+# installed language pack — this is the MVP limit noted in argos_translator.py,
+# and broadening it means shipping more packs, not editing this table alone.
+SUPPORTED_PAIRS: Dict[TranslationService, Optional[Set[Tuple[str, str]]]] = {
+    TranslationService.ARGOS: {("en", "vi")},
+    TranslationService.OPENAI: None,
+    TranslationService.GEMINI: None,
+    TranslationService.ANTHROPIC: None,
+}
+
+# Backends with no language detection of their own need "auto" pinned to a
+# concrete source. Argos assumes English — the dominant case for the academic
+# PDFs this app targets. LLMs detect from content, so they are absent here and
+# "auto" stays "auto" for them.
+_AUTO_SOURCE_SUBSTITUTE: Dict[TranslationService, str] = {
+    TranslationService.ARGOS: "en",
+}
+
+
+def _code(lang: LangLike) -> str:
+    """Accept either a `LanguageCode` or a bare wire string."""
+    return lang.value if isinstance(lang, LanguageCode) else str(lang)
+
+
+def normalize_pair(
+    service: TranslationService, lang_in: LangLike, lang_out: LangLike
+) -> Tuple[str, str]:
+    """Resolve a requested pair to the one the backend will really run.
+
+    Only "auto" moves, and only for backends that cannot detect a source
+    language. Mirrors `ArgosTranslator._setup_translator`, which performs the
+    same substitution on itself.
+    """
+    source = _code(lang_in)
+    target = _code(lang_out)
+    if source == "auto":
+        source = _AUTO_SOURCE_SUBSTITUTE.get(service, source)
+    return source, target
+
+
+def supported_pairs_for(
+    service: TranslationService,
+) -> Optional[List[List[str]]]:
+    """Wire format for `/config/options`: every pair the frontend may offer,
+    or `None` for "unrestricted".
+
+    Auto-source aliases are expanded here rather than re-derived in TypeScript,
+    so the substitution rule above stays the only copy.
+    """
+    pairs = SUPPORTED_PAIRS.get(service)
+    if pairs is None:
+        return None
+    expanded: Set[Tuple[str, str]] = set(pairs)
+    substitute = _AUTO_SOURCE_SUBSTITUTE.get(service)
+    if substitute is not None:
+        expanded |= {
+            ("auto", target) for source, target in pairs if source == substitute
+        }
+    return sorted([source, target] for source, target in expanded)
+
+
+def unsupported_reason(
+    service: TranslationService, lang_in: LangLike, lang_out: LangLike
+) -> Optional[str]:
+    """Why this request cannot run, or `None` if it can.
+
+    Ask about the *effective* service (see `resolve_effective_service`): with no
+    API key, "OpenAI + Japanese" really means "Argos + Japanese".
+    """
+    pairs = SUPPORTED_PAIRS.get(service)
+    if pairs is None:
+        return None
+
+    source, target = normalize_pair(service, lang_in, lang_out)
+    if (source, target) in pairs:
+        return None
+
+    def label(code: str) -> str:
+        try:
+            return LANGUAGE_LABELS[LanguageCode(code)]
+        except ValueError:
+            return code
+
+    allowed = ", ".join(
+        f"{label(s)} → {label(t)}" for s, t in sorted(pairs)
+    )
+    return (
+        f"{SERVICE_LABELS.get(service, service.value)} translates "
+        f"{allowed} only, but {label(source)} → {label(target)} was requested. "
+        f"Add an API key in Settings to use a translator that supports it."
+    )
 
 
 def resolve_languages(

--- a/src/desktop_pdf_translator/translators/capabilities.py
+++ b/src/desktop_pdf_translator/translators/capabilities.py
@@ -1,0 +1,64 @@
+"""Language/service capability rules — the single source of truth for
+"which request actually runs, and with what".
+
+Deliberately free of heavyweight imports (no BabelDOC, no torch, no SDK
+clients), so the API layer can consult it before accepting a job and the test
+suite can exercise it in milliseconds. Importing this module must stay cheap;
+put anything that needs a live translator elsewhere.
+
+Two rules used to live in duplicate:
+
+* **default resolution** — "no language given → use the configured default"
+  lived only inside `PDFProcessor.process_pdf`, while `api/schemas.py` declared
+  non-null defaults of its own that pre-empted it (issue #12);
+* **service fallback** — "an LLM with no API key silently becomes Argos" lived
+  in `PDFProcessor._resolve_effective_service` *and*, copy-pasted, in the
+  `/translate/prewarm` route.
+
+Both now live here.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional, Tuple
+
+from ..config import LanguageCode, TranslationService
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_languages(
+    settings,
+    source_lang: Optional[LanguageCode],
+    target_lang: Optional[LanguageCode],
+) -> Tuple[LanguageCode, LanguageCode]:
+    """Fill in unspecified languages from configuration.
+
+    `None` is the only value that means "unspecified". Callers must not pass a
+    sentinel like `LanguageCode.AUTO` to mean "I didn't choose" — `AUTO` is a
+    real, user-selectable source language.
+    """
+    return (
+        source_lang or settings.translation.default_source_lang,
+        target_lang or settings.translation.default_target_lang,
+    )
+
+
+def resolve_effective_service(
+    settings, requested: TranslationService
+) -> TranslationService:
+    """Pick the service that will actually run given current credentials.
+
+    Argos (offline) is always usable. For LLM services, fall back to Argos when
+    the user has no key configured. Matches the product rule: "Argos is default;
+    LLM wins when a key exists".
+
+    Callers deciding whether a request is *supported* must ask about the
+    effective service, not the requested one: "OpenAI + Japanese" with no key
+    really means "Argos + Japanese", which Argos cannot do.
+    """
+    if settings.has_api_key(requested):
+        return requested
+    logger.info("No API key for %s — falling back to Argos for this run", requested)
+    return TranslationService.ARGOS

--- a/tests/test_translate_language_contract.py
+++ b/tests/test_translate_language_contract.py
@@ -1,0 +1,199 @@
+"""The language contract between the toolbar, the API and the pipeline (#12).
+
+Deliberately imports only `api.schemas`, `translators.capabilities` and
+`processors.pdf_cache` — never `api.routes.translation`, which drags in
+BabelDOC + torch and turns a sub-second run into a minute-long one (the same
+trade-off `test_pdf_export_api.py` documents). Everything asserted here is a
+pure decision, so nothing is lost by staying out of the heavy modules.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from desktop_pdf_translator.api.schemas import PrewarmRequest, TranslateRequest
+from desktop_pdf_translator.config import LanguageCode, TranslationService
+from desktop_pdf_translator.processors.pdf_cache import _make_cache_key
+from desktop_pdf_translator.translators.capabilities import (
+    normalize_pair,
+    resolve_effective_service,
+    resolve_languages,
+    supported_pairs_for,
+    unsupported_reason,
+)
+
+
+class _FakeTranslationSettings:
+    def __init__(self, source: LanguageCode, target: LanguageCode):
+        self.default_source_lang = source
+        self.default_target_lang = target
+
+
+class _FakeSettings:
+    """Just the surface `capabilities` touches, so the tests don't need a real
+    config file on disk."""
+
+    def __init__(
+        self,
+        source: LanguageCode = LanguageCode.ENGLISH,
+        target: LanguageCode = LanguageCode.JAPANESE,
+        keyed: tuple[TranslationService, ...] = (),
+    ):
+        self.translation = _FakeTranslationSettings(source, target)
+        self._keyed = set(keyed)
+
+    def has_api_key(self, service: TranslationService) -> bool:
+        if service == TranslationService.ARGOS:
+            return True
+        return service in self._keyed
+
+
+# ---------------------------------------------------------------------------
+# Request schema — "unspecified" must be None, never a sentinel
+# ---------------------------------------------------------------------------
+
+
+def test_translate_request_leaves_languages_unspecified():
+    """The regression this issue is about: non-null defaults here silently
+    pre-empted the configured default and pinned every run to Vietnamese."""
+    request = TranslateRequest(file_path="paper.pdf")
+    assert request.source_lang is None
+    assert request.target_lang is None
+    assert request.service is None
+
+
+def test_translate_request_keeps_explicit_languages():
+    request = TranslateRequest(
+        file_path="paper.pdf", source_lang="en", target_lang="ja"
+    )
+    assert request.source_lang is LanguageCode.ENGLISH
+    assert request.target_lang is LanguageCode.JAPANESE
+
+
+def test_prewarm_request_leaves_languages_unspecified():
+    payload = PrewarmRequest()
+    assert payload.source_lang is None
+    assert payload.target_lang is None
+
+
+# ---------------------------------------------------------------------------
+# Default resolution
+# ---------------------------------------------------------------------------
+
+
+def test_unspecified_languages_fall_back_to_configured_defaults():
+    settings = _FakeSettings(
+        source=LanguageCode.ENGLISH, target=LanguageCode.JAPANESE
+    )
+    assert resolve_languages(settings, None, None) == (
+        LanguageCode.ENGLISH,
+        LanguageCode.JAPANESE,
+    )
+
+
+def test_a_request_without_languages_uses_the_configured_defaults():
+    """End of the wire: nothing between `TranslateRequest` and the pipeline may
+    re-introduce a default of its own."""
+    settings = _FakeSettings(
+        source=LanguageCode.AUTO, target=LanguageCode.CHINESE_SIMPLIFIED
+    )
+    request = TranslateRequest(file_path="paper.pdf")
+    assert resolve_languages(settings, request.source_lang, request.target_lang) == (
+        LanguageCode.AUTO,
+        LanguageCode.CHINESE_SIMPLIFIED,
+    )
+
+
+def test_explicit_languages_win_over_configuration():
+    settings = _FakeSettings(target=LanguageCode.VIETNAMESE)
+    _, target = resolve_languages(settings, None, LanguageCode.JAPANESE)
+    assert target is LanguageCode.JAPANESE
+
+
+# ---------------------------------------------------------------------------
+# Effective service
+# ---------------------------------------------------------------------------
+
+
+def test_llm_without_a_key_falls_back_to_argos():
+    settings = _FakeSettings(keyed=())
+    assert (
+        resolve_effective_service(settings, TranslationService.OPENAI)
+        is TranslationService.ARGOS
+    )
+
+
+def test_llm_with_a_key_is_kept():
+    settings = _FakeSettings(keyed=(TranslationService.OPENAI,))
+    assert (
+        resolve_effective_service(settings, TranslationService.OPENAI)
+        is TranslationService.OPENAI
+    )
+
+
+# ---------------------------------------------------------------------------
+# Capability matrix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "service, lang_in, lang_out",
+    [
+        (TranslationService.ARGOS, "en", "vi"),
+        # Argos has no language detection and pins "auto" to English itself.
+        (TranslationService.ARGOS, "auto", "vi"),
+        (TranslationService.ARGOS, LanguageCode.AUTO, LanguageCode.VIETNAMESE),
+        # LLMs are unrestricted.
+        (TranslationService.OPENAI, "en", "ja"),
+        (TranslationService.ANTHROPIC, "zh-tw", "vi"),
+    ],
+)
+def test_supported_pairs_are_accepted(service, lang_in, lang_out):
+    assert unsupported_reason(service, lang_in, lang_out) is None
+
+
+@pytest.mark.parametrize("target", ["ja", "zh-cn", "zh-tw", "en"])
+def test_argos_rejects_targets_it_has_no_pack_for(target):
+    reason = unsupported_reason(TranslationService.ARGOS, "en", target)
+    assert reason is not None
+    # The message is user-facing — it must name the way out, not just the fault.
+    assert "API key" in reason
+
+
+def test_auto_only_substitutes_for_backends_without_detection():
+    assert normalize_pair(TranslationService.ARGOS, "auto", "vi") == ("en", "vi")
+    # LLMs detect from content, so "auto" stays "auto" for them.
+    assert normalize_pair(TranslationService.OPENAI, "auto", "vi") == ("auto", "vi")
+
+
+def test_wire_format_expands_auto_aliases_for_the_frontend():
+    """The frontend does a plain membership test, so the substitution rule must
+    already be applied server-side."""
+    assert supported_pairs_for(TranslationService.ARGOS) == [
+        ["auto", "vi"],
+        ["en", "vi"],
+    ]
+    assert supported_pairs_for(TranslationService.OPENAI) is None
+
+
+# ---------------------------------------------------------------------------
+# PDF cache key
+# ---------------------------------------------------------------------------
+
+
+def _key(lang_in: str, lang_out: str) -> str:
+    return _make_cache_key("f" * 64, lang_in, lang_out, "openai", "gpt-4.1", "1")
+
+
+def test_cache_key_separates_source_languages():
+    """Source is part of the key now that it reaches the pipeline: the LLM
+    system prompt names it, so "auto" and "en" can yield different bytes."""
+    assert _key("auto", "vi") != _key("en", "vi")
+
+
+def test_cache_key_separates_target_languages():
+    assert _key("en", "vi") != _key("en", "ja")
+
+
+def test_cache_key_is_stable_for_identical_inputs():
+    assert _key("en", "vi") == _key("en", "vi")


### PR DESCRIPTION
Closes #12

The From/To selectors persisted to config but had no effect on output — picking Japanese still produced Vietnamese.

## Root cause

Two defects that masked each other:

1. `TranslateRequest` declared `source_lang = LanguageCode.AUTO` and `target_lang = LanguageCode.VIETNAMESE` as field defaults. Both are truthy, so `process_pdf`'s `source_lang or settings…default_source_lang` fallback was dead code. (`service: Optional[...] = None` on the next line did it correctly.) `PrewarmRequest` had the same sentinels.
2. `useTranslation.start()` posted only `file_path` / `visible_page` / `bypass_cache`, so the selection never left the webview.

## Why this isn't a one-line fix

Argos is the default backend, ships one language pack (`{("en","vi")}`), and `process_pdf` silently falls back to it whenever the preferred LLM has no key. Just forwarding `target_lang` would trade a silent wrong-output for a **hard `ValueError` minutes into a run** — raised from inside `translate()`, after file validation, translator setup and BabelDOC layout, with a partial artifact already on disk.

So the fix pairs the plumbing with a capability model and a pre-flight gate.

## Changes

- **`translators/capabilities.py`** (new) — single source of truth for which requests can run. Holds `SUPPORTED_PAIRS` (`None` = unrestricted, a set = exhaustive), the `auto`→`en` substitution Argos performs on itself, `resolve_languages`, and `resolve_effective_service` — the last previously duplicated between `PDFProcessor` and the `/translate/prewarm` route. Deliberately free of BabelDOC/torch/SDK imports so the API layer and tests can consult it cheaply. `argos_translator.py` now reads its own `_SUPPORTED_PAIRS` from here, so a request can't be accepted as valid and then rejected mid-run.
- **`POST /translate`** — pre-flights the pair and returns **422** before creating the job, checked against the *effective* service, so "OpenAI + Japanese" with no key is refused rather than silently downgraded into an Argos run that cannot succeed.
- **`GET /config/options`** — gains `supported_pairs` per service, auto-source aliases expanded server-side so the frontend tests membership instead of reimplementing the matrix in TypeScript. The route's duplicate language-label map moved into the capability module.
- **Frontend** — selection travels with the request, built by the new pure `lib/translate-request.ts`. This also closes a race the config lookup could not: changing a dropdown fires an async PUT, so a Translate click landing first would run the *previous* selection. The To dropdown greys out unreachable targets; a 422 surfaces as its own toast with the server's sentence, not `ApiError`'s `"422: "` prefix.
- **`pdf_cache.py`** — `lang_in` added to the cache key. It was excluded on the premise that source never affects output; that held only while the API pinned every request to `auto`. The LLM system prompts name the source explicitly, so `auto` and `en` can produce different bytes and must not collide.

Two deliberate choices worth flagging for review:

- The **requested** service goes on the wire, not the effective one — the sidecar does its own no-key fallback and emits the "falling back to Argos" notice that pre-resolving in the frontend would silence.
- A disabled Radix `SelectItem` sets `pointer-events: none` (and is skipped in keyboard nav), so the "why" renders as inline text plus a footer note rather than a hover tooltip.

## Testing

`tests/test_translate_language_contract.py` covers the whole contract — `None`-defaulted request fields, default resolution, the no-key fallback, the capability matrix, and cache-key separation — while importing only `schemas`, `capabilities` and `pdf_cache`, keeping it a sub-second run. `desktop/src/lib/translate-request.test.ts` covers the body builder, the effective-service rule and pair membership.

- `python -m pytest tests` — 58 passed
- `cd desktop && pnpm test` — 36 passed
- `cd desktop && pnpm build` — `tsc` clean

Also exercised the real router once (it pulls torch, so no test covers it): `openai + ja` with no key → 422 with the user-facing sentence; missing file → 400 as before.

## Notes for the reviewer

- **Existing PDF-cache entries stop matching** on the first run after this and LRU-evict naturally — one slower re-translate per cached document. No `PIPELINE_VERSION` bump is needed; adding a field to the payload already changes every key.
- **The manual end-to-end is unrun.** The pieces and the HTTP contract are verified, but nobody has yet translated a real PDF to Japanese with a live API key on this branch. Worth doing before merge.
- Broadening Argos beyond en→vi is deliberately out of scope — it means shipping more packs, not editing `SUPPORTED_PAIRS` alone. `rag_chain.py`'s hardcoded `lang_out="vi"` is left to #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss9ZsytfqdJiXHm77X8kC6
