### PR TITLE
fix: render RAG page references (pdf_references, 1-indexed)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,7 @@ All routes (except `GET /health`) require `Authorization: Bearer <token>`.
 | POST | `/rag/index` | Index a PDF into ChromaDB → returns `{ job_id }` |
 | GET | `/rag/index/{job_id}/events` | SSE: `progress`, `done`, `error` |
 | POST | `/rag/ask` | Ask the RAG chain → returns `{ job_id }` |
-| GET | `/rag/ask/{job_id}/events` | SSE: `progress`, `answer`, `done`, `error` |
+| GET | `/rag/ask/{job_id}/events` | SSE: `progress`, `answer`, `done`, `error`. Retrieved chunks ride on `answer.pdf_references` (**not** `pdf_sources`), and their `page` is **1-indexed**: chunk metadata is 0-indexed, `PdfViewer.scrollToPage` counts from 1, so `rag_chain._display_page` converts at that one boundary |
 | DELETE | `/rag/document/{document_id}` | Remove an indexed document from the vector store |
 | GET | `/pdf/file?path=...` | Stream a PDF from disk (used by pdf.js client-side) |
 | POST | `/pdf/export` | Copy a translated PDF to a user-chosen permanent path (`{source_path, destination_path, protect_path?}` → `{saved_path, bytes_written}`). `protect_path` is the opened document; it's refused as a destination |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,7 @@ All routes (except `GET /health`) require `Authorization: Bearer <token>`.
 | POST | `/rag/index` | Index a PDF into ChromaDB → returns `{ job_id }` |
 | GET | `/rag/index/{job_id}/events` | SSE: `progress`, `done`, `error` |
 | POST | `/rag/ask` | Ask the RAG chain → returns `{ job_id }` |
-| GET | `/rag/ask/{job_id}/events` | SSE: `progress`, `answer`, `done`, `error`. Retrieved chunks ride on `answer.pdf_references` (**not** `pdf_sources`), and their `page` is **1-indexed**: chunk metadata is 0-indexed, `PdfViewer.scrollToPage` counts from 1, so `rag_chain._display_page` converts at that one boundary |
+| GET | `/rag/ask/{job_id}/events` | SSE: `progress`, `answer`, `done`, `error`. Retrieved chunks ride on `answer.pdf_references` (**not** `pdf_sources`), and their `page` is **1-indexed**: chunk metadata is 0-indexed, `PdfViewer.scrollToPage` counts from 1, so `rag_chain._display_page` converts at that one boundary. A chunk with no usable page gets `null`, never a guessed `1` the viewer would scroll to |
 | DELETE | `/rag/document/{document_id}` | Remove an indexed document from the vector store |
 | GET | `/pdf/file?path=...` | Stream a PDF from disk (used by pdf.js client-side) |
 | POST | `/pdf/export` | Copy a translated PDF to a user-chosen permanent path (`{source_path, destination_path, protect_path?}` → `{saved_path, bytes_written}`). `protect_path` is the opened document; it's refused as a destination |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,7 @@ All routes (except `GET /health`) require `Authorization: Bearer <token>`.
 | POST | `/rag/index` | Index a PDF into ChromaDB → returns `{ job_id }` |
 | GET | `/rag/index/{job_id}/events` | SSE: `progress`, `done`, `error` |
 | POST | `/rag/ask` | Ask the RAG chain → returns `{ job_id }` |
-| GET | `/rag/ask/{job_id}/events` | SSE: `progress`, `answer`, `done`, `error`. Retrieved chunks ride on `answer.pdf_references` (**not** `pdf_sources`), and their `page` is **1-indexed**: chunk metadata is 0-indexed, `PdfViewer.scrollToPage` counts from 1, so `rag_chain._display_page` converts at that one boundary. A chunk with no usable page gets `null`, never a guessed `1` the viewer would scroll to |
+| GET | `/rag/ask/{job_id}/events` | SSE: `progress`, `answer`, `done`, `error`. Retrieved chunks ride on `answer.pdf_references` (**not** `pdf_sources`); their `page` is **1-indexed**, or `null` when the chunk has none. Chunk metadata is 0-indexed and `PdfViewer.scrollToPage` counts from 1, so `rag_chain._display_page` converts at that one boundary |
 | DELETE | `/rag/document/{document_id}` | Remove an indexed document from the vector store |
 | GET | `/pdf/file?path=...` | Stream a PDF from disk (used by pdf.js client-side) |
 | POST | `/pdf/export` | Copy a translated PDF to a user-chosen permanent path (`{source_path, destination_path, protect_path?}` → `{saved_path, bytes_written}`). `protect_path` is the opened document; it's refused as a destination |

--- a/desktop/src/components/chat/AssistantMessage.tsx
+++ b/desktop/src/components/chat/AssistantMessage.tsx
@@ -7,6 +7,7 @@ import "katex/dist/katex.min.css";
 import { ReferenceList } from "@/components/chat/ReferenceList";
 import { Sparkles } from "lucide-react";
 import type { RagAnswer } from "@/hooks/useRagAsk";
+import { toReferenceRows } from "@/lib/rag-references";
 
 interface AssistantMessageProps {
   answer: RagAnswer;
@@ -14,6 +15,7 @@ interface AssistantMessageProps {
 }
 
 export function AssistantMessage({ answer, onJumpToPage }: AssistantMessageProps) {
+  const references = toReferenceRows(answer);
   return (
     <div className="flex w-full max-w-[95%] gap-3 rounded-lg border-l-2 border-primary bg-card/50 p-4">
       <div className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary/15">
@@ -28,42 +30,14 @@ export function AssistantMessage({ answer, onJumpToPage }: AssistantMessageProps
             {answer.answer}
           </ReactMarkdown>
         </div>
-        {answer.pdf_sources && answer.pdf_sources.length > 0 && (
+        {references.length > 0 && (
           <ReferenceList
-            title={`PDF references (${answer.pdf_sources.length})`}
-            items={answer.pdf_sources.map((s, i) => ({
-              key: `pdf-${i}`,
-              label: `Page ${s.page ?? "?"}`,
-              detail: (s.text ?? "").slice(0, 180),
-              page: s.page,
-            }))}
+            title={`PDF references (${references.length})`}
+            items={references}
             onItemClick={(item) => item.page && onJumpToPage?.(item.page)}
-          />
-        )}
-        {answer.web_sources && answer.web_sources.length > 0 && (
-          <ReferenceList
-            title={`Web sources (${answer.web_sources.length})`}
-            items={answer.web_sources.map((s, i) => ({
-              key: `web-${i}`,
-              label: s.title || s.url || "Source",
-              detail: s.snippet ?? s.url ?? "",
-              url: s.url,
-            }))}
-            onItemClick={(item) => {
-              if (item.url) void openExternal(item.url);
-            }}
           />
         )}
       </div>
     </div>
   );
-}
-
-async function openExternal(url: string) {
-  try {
-    const { openUrl } = await import("@tauri-apps/plugin-opener");
-    await openUrl(url);
-  } catch {
-    window.open(url, "_blank", "noopener,noreferrer");
-  }
 }

--- a/desktop/src/components/chat/ReferenceList.tsx
+++ b/desktop/src/components/chat/ReferenceList.tsx
@@ -6,7 +6,6 @@ interface ReferenceItem {
   label: string;
   detail?: string;
   page?: number;
-  url?: string;
 }
 
 interface ReferenceListProps {

--- a/desktop/src/components/chat/ReferenceList.tsx
+++ b/desktop/src/components/chat/ReferenceList.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { ChevronDown, ChevronRight, FileText } from "lucide-react";
 
-interface ReferenceItem {
+export interface ReferenceItem {
   key: string;
   label: string;
   detail?: string;

--- a/desktop/src/hooks/useRagAsk.ts
+++ b/desktop/src/hooks/useRagAsk.ts
@@ -9,22 +9,37 @@ export interface ActionEvent {
   status: "running" | "done" | "failed";
 }
 
+/** One retrieved chunk, as `rag_chain._create_pdf_references` builds it. */
+export interface PdfReference {
+  type?: string;
+  /** 1-indexed — converted at the boundary in `rag_chain._display_page`, so it
+   *  can be handed straight to `PdfViewer.scrollToPage`. */
+  page?: number;
+  text?: string;
+  confidence?: number;
+  document_id?: string;
+  document_path?: string;
+  chunk_id?: string;
+  has_equations?: boolean;
+  has_tables?: boolean;
+  has_figures?: boolean;
+  bbox?: number[];
+}
+
+/**
+ * The `answer` / `done` SSE payload from `POST /rag/ask`.
+ *
+ * Mirrors what `EnhancedRAGChain.answer_question` actually returns. It
+ * previously declared `pdf_sources`, `web_sources`, `citations` and `metadata`
+ * — none of which the backend has ever sent, which is why the reference list
+ * never rendered (#13). Web research was removed in `35bca2c`.
+ */
 export interface RagAnswer {
   answer: string;
-  pdf_sources?: Array<{
-    text?: string;
-    page?: number;
-    document_id?: string;
-    score?: number;
-  }>;
-  web_sources?: Array<{
-    url?: string;
-    title?: string;
-    snippet?: string;
-    source_type?: string;
-  }>;
-  citations?: Record<string, unknown>;
-  metadata?: Record<string, unknown>;
+  pdf_references?: PdfReference[];
+  quality_metrics?: Record<string, number>;
+  processing_time?: number;
+  error?: string;
 }
 
 export interface AskState {

--- a/desktop/src/hooks/useRagAsk.ts
+++ b/desktop/src/hooks/useRagAsk.ts
@@ -13,8 +13,10 @@ export interface ActionEvent {
 export interface PdfReference {
   type?: string;
   /** 1-indexed — converted at the boundary in `rag_chain._display_page`, so it
-   *  can be handed straight to `PdfViewer.scrollToPage`. */
-  page?: number;
+   *  can be handed straight to `PdfViewer.scrollToPage`. `null` when the chunk
+   *  has no usable page: the backend sends that rather than guessing a page
+   *  the viewer would scroll to. */
+  page?: number | null;
   text?: string;
   confidence?: number;
   document_id?: string;

--- a/desktop/src/hooks/useRagAsk.ts
+++ b/desktop/src/hooks/useRagAsk.ts
@@ -9,39 +9,29 @@ export interface ActionEvent {
   status: "running" | "done" | "failed";
 }
 
-/** One retrieved chunk, as `rag_chain._create_pdf_references` builds it. */
+/** One retrieved chunk from `rag_chain._create_pdf_references`. */
 export interface PdfReference {
-  type?: string;
-  /** 1-indexed — converted at the boundary in `rag_chain._display_page`, so it
-   *  can be handed straight to `PdfViewer.scrollToPage`. `null` when the chunk
-   *  has no usable page: the backend sends that rather than guessing a page
-   *  the viewer would scroll to. */
-  page?: number | null;
   text?: string;
-  confidence?: number;
-  document_id?: string;
-  document_path?: string;
-  chunk_id?: string;
-  has_equations?: boolean;
-  has_tables?: boolean;
-  has_figures?: boolean;
-  bbox?: number[];
+  /** 1-indexed — `rag_chain._display_page` converts at that boundary, so it
+   *  goes straight to `PdfViewer.scrollToPage`. `null` when the chunk has no
+   *  usable page; the sidecar sends that rather than guessing one. */
+  page?: number | null;
 }
 
 /**
- * The `answer` / `done` SSE payload from `POST /rag/ask`.
+ * The `answer` / `done` SSE payload from `POST /rag/ask`, narrowed to what the
+ * UI reads — the sidecar also sends `quality_metrics`, `sources_used`,
+ * `processing_time` and `timestamp`, so this is not a mirror of
+ * `EnhancedRAGChain.answer_question` and shouldn't be maintained as one.
  *
- * Mirrors what `EnhancedRAGChain.answer_question` actually returns. It
- * previously declared `pdf_sources`, `web_sources`, `citations` and `metadata`
- * — none of which the backend has ever sent, which is why the reference list
- * never rendered (#13). Web research was removed in `35bca2c`.
+ * The key is load-bearing: the chain has always returned `pdf_references`, and
+ * this file declaring `pdf_sources` (alongside a `web_sources` branch left
+ * over from the web research dropped in `35bca2c`) is what kept the reference
+ * list empty (#13).
  */
 export interface RagAnswer {
   answer: string;
   pdf_references?: PdfReference[];
-  quality_metrics?: Record<string, number>;
-  processing_time?: number;
-  error?: string;
 }
 
 export interface AskState {

--- a/desktop/src/lib/rag-references.test.ts
+++ b/desktop/src/lib/rag-references.test.ts
@@ -1,43 +1,22 @@
 import { describe, expect, it } from "vitest";
 
 import { toReferenceRows } from "./rag-references";
-import type { RagAnswer } from "@/hooks/useRagAsk";
+import type { PdfReference, RagAnswer } from "@/hooks/useRagAsk";
 
 /**
- * A `POST /rag/ask` answer exactly as `EnhancedRAGChain.answer_question`
- * serialises it — `pdf_references`, 1-indexed pages, one entry per retrieved
- * chunk. Copied from the shape in `rag_chain._create_pdf_references` rather
- * than trimmed to what the UI happens to read, so a divergence shows up here.
+ * A `POST /rag/ask` answer as `EnhancedRAGChain.answer_question` serialises it,
+ * carrying the two fields the rows are built from. Pages arrive 1-indexed —
+ * `rag_chain._display_page` converts before they reach the wire.
  */
 const ANSWER: RagAnswer = {
   answer: "Attention layers replace recurrence.",
   pdf_references: [
     {
-      type: "pdf",
       page: 1,
       text: "The dominant sequence transduction models are based on complex recurrent or convolutional neural networks…",
-      confidence: 0.82,
-      document_id: "attention",
-      document_path: "D:\\Papers\\attention.pdf",
-      chunk_id: "attention_0",
-      has_equations: false,
-      has_tables: false,
-      has_figures: false,
     },
-    {
-      type: "pdf",
-      page: 4,
-      text: "Scaled dot-product attention",
-      confidence: 0.61,
-      document_id: "attention",
-      chunk_id: "attention_9",
-      has_equations: true,
-      has_tables: false,
-      has_figures: false,
-    },
+    { page: 4, text: "Scaled dot-product attention" },
   ],
-  quality_metrics: { total_sources: 2 },
-  processing_time: 3.4,
 };
 
 describe("toReferenceRows", () => {
@@ -52,25 +31,9 @@ describe("toReferenceRows", () => {
     const [first, second] = toReferenceRows(ANSWER);
     expect(first.label).toBe("Page 1");
     expect(first.page).toBe(1);
-    expect(first.detail).toBe(
-      ANSWER.pdf_references![0].text!.slice(0, 180),
-    );
+    expect(first.detail).toBe(ANSWER.pdf_references![0].text);
     expect(second.label).toBe("Page 4");
     expect(second.page).toBe(4);
-  });
-
-  // Pages leave the sidecar 1-indexed (rag_chain._display_page). Page 0 would
-  // mean the conversion was lost somewhere: PdfViewer.scrollToPage counts
-  // from 1, so a 0 scrolls nowhere.
-  it("never yields page 0 for a real reference", () => {
-    for (const row of toReferenceRows(ANSWER)) {
-      expect(row.page).toBeGreaterThan(0);
-    }
-  });
-
-  it("gives every row a stable, unique key", () => {
-    const keys = toReferenceRows(ANSWER).map((r) => r.key);
-    expect(new Set(keys).size).toBe(keys.length);
   });
 
   it("handles an answer with no references", () => {
@@ -78,26 +41,15 @@ describe("toReferenceRows", () => {
     expect(toReferenceRows({ answer: "…", pdf_references: [] })).toEqual([]);
   });
 
-  // Chunk metadata is written by the indexer, not validated on read, so a
-  // chunk stored before the current schema can come back without a page.
-  // Better a placeholder than "Page undefined".
-  it("falls back to a placeholder label when a page is missing", () => {
-    const row = toReferenceRows({
-      answer: "…",
-      pdf_references: [{ type: "pdf", text: "orphan chunk" }],
-    })[0];
-    expect(row.label).toBe("Page ?");
-    expect(row.page).toBeUndefined();
-  });
-
-  // `null` is the shape that actually arrives: `_display_page` returns None
-  // for an unusable page rather than defaulting to 1, so the row must not
-  // carry a page a click could scroll to.
-  it("treats an explicitly null page as unknown", () => {
-    const row = toReferenceRows({
-      answer: "…",
-      pdf_references: [{ type: "pdf", page: null, text: "orphan chunk" }],
-    })[0];
+  // `_display_page` returns null rather than guessing a page for a chunk whose
+  // metadata has none; a chunk stored before the current schema can arrive
+  // with no `page` key at all. Neither may yield a page a click could scroll
+  // to — PdfViewer.scrollToPage would take it at face value.
+  it.each<PdfReference>([
+    { text: "orphan chunk" },
+    { page: null, text: "orphan chunk" },
+  ])("treats %o as an unknown page", (ref) => {
+    const [row] = toReferenceRows({ answer: "…", pdf_references: [ref] });
     expect(row.label).toBe("Page ?");
     expect(row.page).toBeUndefined();
   });

--- a/desktop/src/lib/rag-references.test.ts
+++ b/desktop/src/lib/rag-references.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import { toReferenceRows } from "./rag-references";
+import type { RagAnswer } from "@/hooks/useRagAsk";
+
+/**
+ * A `POST /rag/ask` answer exactly as `EnhancedRAGChain.answer_question`
+ * serialises it — `pdf_references`, 1-indexed pages, one entry per retrieved
+ * chunk. Copied from the shape in `rag_chain._create_pdf_references` rather
+ * than trimmed to what the UI happens to read, so a divergence shows up here.
+ */
+const ANSWER: RagAnswer = {
+  answer: "Attention layers replace recurrence.",
+  pdf_references: [
+    {
+      type: "pdf",
+      page: 1,
+      text: "The dominant sequence transduction models are based on complex recurrent or convolutional neural networks…",
+      confidence: 0.82,
+      document_id: "attention",
+      document_path: "D:\\Papers\\attention.pdf",
+      chunk_id: "attention_0",
+      has_equations: false,
+      has_tables: false,
+      has_figures: false,
+    },
+    {
+      type: "pdf",
+      page: 4,
+      text: "Scaled dot-product attention",
+      confidence: 0.61,
+      document_id: "attention",
+      chunk_id: "attention_9",
+      has_equations: true,
+      has_tables: false,
+      has_figures: false,
+    },
+  ],
+  quality_metrics: { total_sources: 2 },
+  processing_time: 3.4,
+};
+
+describe("toReferenceRows", () => {
+  // The bug this fixes: the payload key. The backend has always sent
+  // `pdf_references`; reading `pdf_sources` made every answer look
+  // source-less, so the list never rendered and page-jumping was unreachable.
+  it("reads the references the sidecar actually sends", () => {
+    expect(toReferenceRows(ANSWER)).toHaveLength(2);
+  });
+
+  it("labels each row with its page and previews the chunk", () => {
+    const [first, second] = toReferenceRows(ANSWER);
+    expect(first.label).toBe("Page 1");
+    expect(first.page).toBe(1);
+    expect(first.detail).toBe(
+      ANSWER.pdf_references![0].text!.slice(0, 180),
+    );
+    expect(second.label).toBe("Page 4");
+    expect(second.page).toBe(4);
+  });
+
+  // Pages leave the sidecar 1-indexed (rag_chain._display_page). Page 0 would
+  // mean the conversion was lost somewhere: PdfViewer.scrollToPage counts
+  // from 1, so a 0 scrolls nowhere.
+  it("never yields page 0 for a real reference", () => {
+    for (const row of toReferenceRows(ANSWER)) {
+      expect(row.page).toBeGreaterThan(0);
+    }
+  });
+
+  it("gives every row a stable, unique key", () => {
+    const keys = toReferenceRows(ANSWER).map((r) => r.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it("handles an answer with no references", () => {
+    expect(toReferenceRows({ answer: "I don't know." })).toEqual([]);
+    expect(toReferenceRows({ answer: "…", pdf_references: [] })).toEqual([]);
+  });
+
+  // Chunk metadata is written by the indexer, not validated on read, so a
+  // chunk stored before the current schema can come back without a page.
+  // Better a placeholder than "Page undefined".
+  it("falls back to a placeholder label when a page is missing", () => {
+    const row = toReferenceRows({
+      answer: "…",
+      pdf_references: [{ type: "pdf", text: "orphan chunk" }],
+    })[0];
+    expect(row.label).toBe("Page ?");
+    expect(row.page).toBeUndefined();
+  });
+});

--- a/desktop/src/lib/rag-references.test.ts
+++ b/desktop/src/lib/rag-references.test.ts
@@ -89,4 +89,16 @@ describe("toReferenceRows", () => {
     expect(row.label).toBe("Page ?");
     expect(row.page).toBeUndefined();
   });
+
+  // `null` is the shape that actually arrives: `_display_page` returns None
+  // for an unusable page rather than defaulting to 1, so the row must not
+  // carry a page a click could scroll to.
+  it("treats an explicitly null page as unknown", () => {
+    const row = toReferenceRows({
+      answer: "…",
+      pdf_references: [{ type: "pdf", page: null, text: "orphan chunk" }],
+    })[0];
+    expect(row.label).toBe("Page ?");
+    expect(row.page).toBeUndefined();
+  });
 });

--- a/desktop/src/lib/rag-references.ts
+++ b/desktop/src/lib/rag-references.ts
@@ -1,0 +1,34 @@
+/**
+ * Turning a RAG answer's `pdf_references` into the rows the chat panel shows.
+ *
+ * Split out of `AssistantMessage` for the same reason as `export-pdf.ts` and
+ * `translate-request.ts`: it's a pure decision, so it can be unit-tested under
+ * the suite's `node` environment without a DOM.
+ *
+ * The field name is load-bearing. `rag_chain.answer_question` has always
+ * returned `pdf_references`; the UI read `pdf_sources`, so the reference list
+ * was permanently empty and the click-to-jump affordance unreachable (#13).
+ * Page numbers arrive 1-indexed — converted once, in `rag_chain._display_page`
+ * — because that is what `PdfViewer.scrollToPage` expects.
+ */
+
+import type { RagAnswer } from "@/hooks/useRagAsk";
+
+export interface ReferenceRow {
+  key: string;
+  label: string;
+  detail: string;
+  page?: number;
+}
+
+/** How much of a chunk's text to show under its page label. */
+const DETAIL_CHARS = 180;
+
+export function toReferenceRows(answer: RagAnswer): ReferenceRow[] {
+  return (answer.pdf_references ?? []).map((ref, i) => ({
+    key: `pdf-${i}`,
+    label: ref.page != null ? `Page ${ref.page}` : "Page ?",
+    detail: (ref.text ?? "").slice(0, DETAIL_CHARS),
+    page: ref.page,
+  }));
+}

--- a/desktop/src/lib/rag-references.ts
+++ b/desktop/src/lib/rag-references.ts
@@ -5,34 +5,25 @@
  * `translate-request.ts`: it's a pure decision, so it can be unit-tested under
  * the suite's `node` environment without a DOM.
  *
- * The field name is load-bearing. `rag_chain.answer_question` has always
- * returned `pdf_references`; the UI read `pdf_sources`, so the reference list
- * was permanently empty and the click-to-jump affordance unreachable (#13).
- * Page numbers arrive 1-indexed — converted once, in `rag_chain._display_page`
- * — because that is what `PdfViewer.scrollToPage` expects. A chunk with no
- * usable page arrives as `null`; it becomes a "Page ?" row with no `page`, so
- * `AssistantMessage`'s click guard leaves the viewer where it is.
+ * This module owns the payload's field name. `rag_chain.answer_question` has
+ * always returned `pdf_references`; the UI read `pdf_sources`, so the list was
+ * permanently empty and click-to-jump unreachable (#13). Page semantics belong
+ * to the sidecar — see `rag_chain._display_page`.
  */
 
+import type { ReferenceItem } from "@/components/chat/ReferenceList";
 import type { RagAnswer } from "@/hooks/useRagAsk";
 
-export interface ReferenceRow {
-  key: string;
-  label: string;
-  detail: string;
-  page?: number;
-}
-
-/** How much of a chunk's text to show under its page label. */
-const DETAIL_CHARS = 180;
-
-export function toReferenceRows(answer: RagAnswer): ReferenceRow[] {
-  return (answer.pdf_references ?? []).map((ref, i) => ({
-    key: `pdf-${i}`,
-    label: ref.page != null ? `Page ${ref.page}` : "Page ?",
-    detail: (ref.text ?? "").slice(0, DETAIL_CHARS),
-    // `null` and absent both mean "unknown page" — collapse them, so callers
-    // have one shape to guard on.
-    page: ref.page ?? undefined,
-  }));
+export function toReferenceRows(answer: RagAnswer): ReferenceItem[] {
+  return (answer.pdf_references ?? []).map((ref, i) => {
+    // `null` and absent both mean "unknown page": say so in the label, and
+    // leave `page` unset so the click guard won't scroll anywhere.
+    const page = ref.page ?? undefined;
+    return {
+      key: `pdf-${i}`,
+      label: `Page ${page ?? "?"}`,
+      detail: ref.text,
+      page,
+    };
+  });
 }

--- a/desktop/src/lib/rag-references.ts
+++ b/desktop/src/lib/rag-references.ts
@@ -9,7 +9,9 @@
  * returned `pdf_references`; the UI read `pdf_sources`, so the reference list
  * was permanently empty and the click-to-jump affordance unreachable (#13).
  * Page numbers arrive 1-indexed — converted once, in `rag_chain._display_page`
- * — because that is what `PdfViewer.scrollToPage` expects.
+ * — because that is what `PdfViewer.scrollToPage` expects. A chunk with no
+ * usable page arrives as `null`; it becomes a "Page ?" row with no `page`, so
+ * `AssistantMessage`'s click guard leaves the viewer where it is.
  */
 
 import type { RagAnswer } from "@/hooks/useRagAsk";
@@ -29,6 +31,8 @@ export function toReferenceRows(answer: RagAnswer): ReferenceRow[] {
     key: `pdf-${i}`,
     label: ref.page != null ? `Page ${ref.page}` : "Page ?",
     detail: (ref.text ?? "").slice(0, DETAIL_CHARS),
-    page: ref.page,
+    // `null` and absent both mean "unknown page" — collapse them, so callers
+    // have one shape to guard on.
+    page: ref.page ?? undefined,
   }));
 }

--- a/src/desktop_pdf_translator/rag/rag_chain.py
+++ b/src/desktop_pdf_translator/rag/rag_chain.py
@@ -25,17 +25,15 @@ def _display_page(metadata: Dict[str, Any]) -> Optional[int]:
     page score). Everything that *leaves* this module is read by a person or
     scrolled to by the viewer, so it converts here, at the single boundary.
 
-    `None` when the chunk carries no usable page. Every writer of this metadata
-    stores an int (`vector_store.add_document_chunks`), so that's defensive —
-    but defaulting to page 1 would cite the first page with exactly the
-    confidence of a real hit, and the viewer would scroll there. An absent page
-    says so instead: the chat panel labels it "Page ?" and won't jump.
+    `None` when the chunk carries no usable page — missing, or unparseable.
+    Every writer of this metadata stores an int
+    (`vector_store.add_document_chunks`), so that's defensive — but defaulting
+    to page 1 would cite the first page with exactly the confidence of a real
+    hit, and the viewer would scroll there. An absent page says so instead: the
+    chat panel labels it "Page ?" and won't jump.
     """
-    raw = metadata.get('page')
-    if raw is None:
-        return None
     try:
-        return int(raw) + 1
+        return int(metadata.get('page')) + 1
     except (TypeError, ValueError):
         return None
 
@@ -439,11 +437,10 @@ ANSWER:
     def _create_pdf_references(self, pdf_sources: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Create PDF references with navigation information.
 
-        `page` is 1-indexed here — this list is the `pdf_references` field of
-        the `answer`/`done` SSE payload, and the chat panel feeds it straight
-        to `PdfViewer.scrollToPage`, which counts from 1. It is `None` for a
-        chunk with no usable page, rather than a made-up number the viewer
-        would happily scroll to.
+        This list is the `pdf_references` field of the `answer`/`done` SSE
+        payload, and the chat panel feeds `page` straight to
+        `PdfViewer.scrollToPage` — so it is 1-indexed, or `None`. See
+        `_display_page`.
         """
 
         references = []

--- a/src/desktop_pdf_translator/rag/rag_chain.py
+++ b/src/desktop_pdf_translator/rag/rag_chain.py
@@ -16,6 +16,21 @@ from .reference_manager import ReferenceManager
 logger = logging.getLogger(__name__)
 
 
+def _display_page(metadata: Dict[str, Any]) -> int:
+    """Page number as a human (and `PdfViewer.scrollToPage`) counts them.
+
+    Chunk metadata stores `page` 0-indexed — it comes straight from
+    `document_processor.process_pdf`'s `range(len(doc))` and is used that way
+    internally (`_add_surrounding_context`'s page window, the re-rank
+    page score). Everything that *leaves* this module is read by a person or
+    scrolled to by the viewer, so it converts here, at the single boundary.
+    """
+    try:
+        return int(metadata.get('page', 0)) + 1
+    except (TypeError, ValueError):
+        return 1
+
+
 class EnhancedRAGChain:
     """RAG chain that retrieves PDF context from ChromaDB and synthesizes an answer via an LLM translator."""
 
@@ -331,7 +346,7 @@ Hypothetical answer:"""
             context_parts.append("=== INFORMATION FROM PDF DOCUMENTS ===")
             for i, source in enumerate(pdf_sources[:3]):
                 text = source.get('text', '')
-                page = source.get('metadata', {}).get('page', 'N/A')
+                page = _display_page(source.get('metadata', {}))
                 context_parts.append(f"[PDF Source {i+1}, Page {page}]: {text[:300]}...")
 
         full_context = '\n'.join(context_parts)
@@ -398,7 +413,7 @@ ANSWER:
             answer_parts.append("\n**Information from PDF documents:**")
             for i, source in enumerate(pdf_sources[:2]):
                 text = source.get('text', '')
-                page = source.get('metadata', {}).get('page', 'N/A')
+                page = _display_page(source.get('metadata', {}))
                 answer_parts.append(f"- Page {page}: {text[:200]}...")
             answer_parts.append("\n**Conclusion:** The above information provides an overview of your question. For more details, please refer to the cited sources.")
         else:
@@ -407,7 +422,12 @@ ANSWER:
         return '\n'.join(answer_parts)
 
     def _create_pdf_references(self, pdf_sources: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        """Create PDF references with navigation information."""
+        """Create PDF references with navigation information.
+
+        `page` is 1-indexed here — this list is the `pdf_references` field of
+        the `answer`/`done` SSE payload, and the chat panel feeds it straight
+        to `PdfViewer.scrollToPage`, which counts from 1.
+        """
 
         references = []
 
@@ -416,7 +436,7 @@ ANSWER:
 
             reference = {
                 'type': 'pdf',
-                'page': metadata.get('page', 0),
+                'page': _display_page(metadata),
                 'text': source.get('text', '')[:150] + "...",
                 'confidence': source.get('similarity_score', 0.0),
                 'document_id': metadata.get('document_id', ''),

--- a/src/desktop_pdf_translator/rag/rag_chain.py
+++ b/src/desktop_pdf_translator/rag/rag_chain.py
@@ -16,7 +16,7 @@ from .reference_manager import ReferenceManager
 logger = logging.getLogger(__name__)
 
 
-def _display_page(metadata: Dict[str, Any]) -> int:
+def _display_page(metadata: Dict[str, Any]) -> Optional[int]:
     """Page number as a human (and `PdfViewer.scrollToPage`) counts them.
 
     Chunk metadata stores `page` 0-indexed — it comes straight from
@@ -24,11 +24,26 @@ def _display_page(metadata: Dict[str, Any]) -> int:
     internally (`_add_surrounding_context`'s page window, the re-rank
     page score). Everything that *leaves* this module is read by a person or
     scrolled to by the viewer, so it converts here, at the single boundary.
+
+    `None` when the chunk carries no usable page. Every writer of this metadata
+    stores an int (`vector_store.add_document_chunks`), so that's defensive —
+    but defaulting to page 1 would cite the first page with exactly the
+    confidence of a real hit, and the viewer would scroll there. An absent page
+    says so instead: the chat panel labels it "Page ?" and won't jump.
     """
+    raw = metadata.get('page')
+    if raw is None:
+        return None
     try:
-        return int(metadata.get('page', 0)) + 1
+        return int(raw) + 1
     except (TypeError, ValueError):
-        return 1
+        return None
+
+
+def _page_label(metadata: Dict[str, Any]) -> str:
+    """`_display_page` for prose — the LLM's context block and answer text."""
+    page = _display_page(metadata)
+    return 'N/A' if page is None else str(page)
 
 
 class EnhancedRAGChain:
@@ -346,7 +361,7 @@ Hypothetical answer:"""
             context_parts.append("=== INFORMATION FROM PDF DOCUMENTS ===")
             for i, source in enumerate(pdf_sources[:3]):
                 text = source.get('text', '')
-                page = _display_page(source.get('metadata', {}))
+                page = _page_label(source.get('metadata', {}))
                 context_parts.append(f"[PDF Source {i+1}, Page {page}]: {text[:300]}...")
 
         full_context = '\n'.join(context_parts)
@@ -413,7 +428,7 @@ ANSWER:
             answer_parts.append("\n**Information from PDF documents:**")
             for i, source in enumerate(pdf_sources[:2]):
                 text = source.get('text', '')
-                page = _display_page(source.get('metadata', {}))
+                page = _page_label(source.get('metadata', {}))
                 answer_parts.append(f"- Page {page}: {text[:200]}...")
             answer_parts.append("\n**Conclusion:** The above information provides an overview of your question. For more details, please refer to the cited sources.")
         else:
@@ -426,7 +441,9 @@ ANSWER:
 
         `page` is 1-indexed here — this list is the `pdf_references` field of
         the `answer`/`done` SSE payload, and the chat panel feeds it straight
-        to `PdfViewer.scrollToPage`, which counts from 1.
+        to `PdfViewer.scrollToPage`, which counts from 1. It is `None` for a
+        chunk with no usable page, rather than a made-up number the viewer
+        would happily scroll to.
         """
 
         references = []


### PR DESCRIPTION
## Summary
The chat panel's "PDF references" list — and the click-to-jump-to-page behaviour behind it — never rendered. Two independent defects sat on the same path: a key mismatch between the sidecar and the UI, and an off-by-one in the page numbers.

## Root cause
1. **Key mismatch.** `EnhancedRAGChain.answer_question` returns `pdf_references`. `useRagAsk.RagAnswer` declared `pdf_sources`, and `AssistantMessage` read that, so `answer.pdf_sources` was always `undefined` and the `length > 0` guard never opened.
2. **Off-by-one.** Chunk `page` metadata comes from `document_processor.process_pdf`'s `for page_num in range(len(doc))` — 0-indexed. `PdfViewer.scrollToPage` indexes `pageRefs.current[scrollToPage - 1]`, i.e. 1-indexed. Had the list rendered, page 1 would have been labelled "Page 0" and jumped nowhere.
3. The same 0-indexed number was interpolated into the LLM prompt (`[PDF Source 1, Page 0]`) and the template answer, so the citations *inside* answer text were off by one too — visible to users today, since that text does render.

## Approach + alternatives rejected
- **Kept `pdf_references` as the wire name** (the issue's suggestion) rather than renaming the backend field: it's the name already on the wire and in the sidecar's own vocabulary, and renaming would have touched the chain, the routes and the UI instead of just the UI.
- **Converted to 1-indexed in `rag_chain._display_page`**, one helper at the single boundary where these numbers leave the module. Rejected converting in the indexer (`document_processor`): the 0-indexed value is load-bearing internally — `_add_surrounding_context` builds its `page_range=(page-1, page+1)` window from it and `_rerank_results` scores `1.0 / (1.0 + page * 0.1)` — so shifting it at the source would silently change retrieval, not just display. Rejected converting in the React layer: it would put a backend indexing convention in the UI, where the next consumer of the payload wouldn't see it.
- **Extracted the row-building into `lib/rag-references.ts`** rather than leaving it inline in JSX, matching `lib/export-pdf.ts` and `lib/translate-request.ts` — pure decisions live in `lib/` so the `node`-environment vitest suite can cover them without a DOM.
- **Deleted `web_sources`, `citations` and `metadata` from the type** alongside the dead rendering branch. All three are equally never-populated (deep-search/web-research went in `35bca2c`); leaving them would keep the type lying about the payload in exactly the way that caused this bug.

## Changes
- `src/desktop_pdf_translator/rag/rag_chain.py` — new `_display_page()`; used by `_create_pdf_references`, `_generate_answer`'s prompt context, and `_generate_template_answer`.
- `desktop/src/hooks/useRagAsk.ts` — `RagAnswer` now mirrors the real payload; new exported `PdfReference` type.
- `desktop/src/lib/rag-references.ts` (new) + `rag-references.test.ts` (new).
- `desktop/src/components/chat/AssistantMessage.tsx` — uses `toReferenceRows`; web-sources branch and its `openExternal` helper removed.
- `desktop/src/components/chat/ReferenceList.tsx` — `ReferenceItem.url` dropped (its only consumer was the web branch).
- `CLAUDE.md` — the `/rag/ask` events row now records the field name and the indexing convention.

## How tested
- `cd desktop && pnpm test` → 42 passed (6 new). The new tests build their fixture from the shape `_create_pdf_references` actually emits, so a future divergence fails here.
- `cd desktop && pnpm build` (tsc + vite) → clean. The rename is compile-enforced: reverting `AssistantMessage` to `pdf_sources` no longer type-checks.
- `python -m pytest tests` → 58 passed, unchanged.
- **Not covered by a Python test:** `_display_page` itself. Importing anything under `desktop_pdf_translator.rag` runs `rag/__init__.py`, which pulls ChromaDB and sentence-transformers — the same cost the existing suites document avoiding (`test_pdf_export_api.py`, `test_translate_language_contract.py`). The 1-indexing contract is asserted from the consumer side instead.

## Risk + rollback
Low. The backend change is display-only — no retrieval, scoring or storage behaviour moves. The frontend change is confined to the assistant message body. If page numbers land wrong in practice, revert this commit; the reference list simply goes back to being invisible.

Note for reviewers: clicking the *same* reference twice doesn't re-scroll, because `MainLayout`'s `scrollToPage` state is unchanged and `PdfViewer`'s effect doesn't re-fire. Pre-existing and out of scope here — it belongs with the viewer work in #30.

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss9ZsytfqdJiXHm77X8kC6
