### PR TITLE
fix: remove dead chat toggles and correct the About dialog

### DIFF
--- a/desktop/src/components/AboutDialog.tsx
+++ b/desktop/src/components/AboutDialog.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { ExternalLink, FileText } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -9,13 +10,46 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { tauriAvailable } from "@/lib/tauri-ready";
+
+const REPO_URL = "https://github.com/TranBaDat2607/PDFusion";
 
 interface AboutDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
+/**
+ * Version comes from the Tauri shell (`tauri.conf.json`'s `version`), which is
+ * the number the installer, the Programs list and the .msi filename all carry —
+ * i.e. the one a user reporting a bug can actually read off their machine.
+ * Hard-coding it here is how it drifted to "0.2.0 — UI rewrite", a release that
+ * never shipped.
+ */
+function useAppVersion(enabled: boolean): string | null {
+  const [version, setVersion] = useState<string | null>(null);
+
+  useEffect(() => {
+    // `pnpm dev` in a plain browser tab has no shell to ask.
+    if (!enabled || !tauriAvailable()) return;
+    let cancelled = false;
+    void import("@tauri-apps/api/app")
+      .then(({ getVersion }) => getVersion())
+      .then((v) => {
+        if (!cancelled) setVersion(v);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled]);
+
+  return version;
+}
+
 export function AboutDialog({ open, onOpenChange }: AboutDialogProps) {
+  const version = useAppVersion(open);
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
@@ -26,15 +60,17 @@ export function AboutDialog({ open, onOpenChange }: AboutDialogProps) {
             </div>
             <div>
               <DialogTitle>PDFusion</DialogTitle>
-              <DialogDescription>Version 0.2.0 — UI rewrite</DialogDescription>
+              <DialogDescription>
+                {version ? `Version ${version}` : "Translate PDFs, keep the layout"}
+              </DialogDescription>
             </div>
           </div>
         </DialogHeader>
         <ul className="space-y-1.5 text-sm text-muted-foreground">
-          <li>· PDF translation with BabelDOC</li>
+          <li>· PDF translation with layout preserved (BabelDOC)</li>
+          <li>· Argos Translate — offline, no API key needed</li>
           <li>· OpenAI · Gemini · Anthropic Claude</li>
-          <li>· RAG chat with hybrid search + HyDE</li>
-          <li>· Deep multi-hop academic search</li>
+          <li>· RAG chat over the open document (hybrid search + HyDE)</li>
         </ul>
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)}>
@@ -42,7 +78,7 @@ export function AboutDialog({ open, onOpenChange }: AboutDialogProps) {
           </Button>
           <Button asChild>
             <a
-              href="https://github.com/anthropics/claude-code"
+              href={REPO_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="gap-2"

--- a/desktop/src/components/chat/ChatInput.tsx
+++ b/desktop/src/components/chat/ChatInput.tsx
@@ -1,28 +1,17 @@
 import { useEffect, useRef, useState } from "react";
-import { Globe, Send, Sparkles } from "lucide-react";
+import { Send } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 
 interface ChatInputProps {
-  onSubmit: (params: {
-    text: string;
-    includeWebResearch: boolean;
-    useDeepSearch: boolean;
-  }) => void;
+  onSubmit: (params: { text: string }) => void;
   disabled?: boolean;
   busy?: boolean;
 }
 
 export function ChatInput({ onSubmit, disabled, busy }: ChatInputProps) {
   const [text, setText] = useState("");
-  const [web, setWeb] = useState(false);
-  const [deep, setDeep] = useState(false);
   const ref = useRef<HTMLTextAreaElement>(null);
 
   // Auto-grow up to ~4 lines
@@ -40,7 +29,7 @@ export function ChatInput({ onSubmit, disabled, busy }: ChatInputProps) {
   const submit = () => {
     const trimmed = text.trim();
     if (!trimmed || disabled || busy) return;
-    onSubmit({ text: trimmed, includeWebResearch: web, useDeepSearch: deep });
+    onSubmit({ text: trimmed });
     setText("");
   };
 
@@ -76,43 +65,7 @@ export function ChatInput({ onSubmit, disabled, busy }: ChatInputProps) {
           <Send className="h-3.5 w-3.5" />
         </Button>
       </div>
-      <div className="flex items-center gap-2 text-xs text-muted-foreground">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              onClick={() => setWeb((v) => !v)}
-              className={`flex items-center gap-1.5 rounded-full border px-2.5 py-1 transition-colors ${
-                web
-                  ? "border-primary bg-primary/10 text-primary"
-                  : "border-border hover:bg-accent"
-              }`}
-            >
-              <Globe className="h-3 w-3" />
-              Web research
-            </button>
-          </TooltipTrigger>
-          <TooltipContent>Augment answers with live web sources</TooltipContent>
-        </Tooltip>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              onClick={() => setDeep((v) => !v)}
-              className={`flex items-center gap-1.5 rounded-full border px-2.5 py-1 transition-colors ${
-                deep
-                  ? "border-primary bg-primary/10 text-primary"
-                  : "border-border hover:bg-accent"
-              }`}
-            >
-              <Sparkles className="h-3 w-3" />
-              Deep search
-            </button>
-          </TooltipTrigger>
-          <TooltipContent>
-            Multi-hop academic citation search (PubMed, arXiv, Semantic Scholar)
-          </TooltipContent>
-        </Tooltip>
+      <div className="flex items-center text-xs text-muted-foreground">
         <span className="ml-auto opacity-70">Enter to send · Shift+Enter for new line</span>
       </div>
     </div>

--- a/desktop/src/components/chat/ChatPanel.tsx
+++ b/desktop/src/components/chat/ChatPanel.tsx
@@ -80,15 +80,7 @@ export function ChatPanel({
   }, [messages.length, ask.state.actions.length, ask.state.status]);
 
   const handleSubmit = useCallback(
-    ({
-      text,
-      includeWebResearch,
-      useDeepSearch,
-    }: {
-      text: string;
-      includeWebResearch: boolean;
-      useDeepSearch: boolean;
-    }) => {
+    ({ text }: { text: string }) => {
       setMessages((prev) => [
         ...prev,
         { id: ++messageCounter, kind: "user", text },
@@ -97,8 +89,6 @@ export function ChatPanel({
       void ask.ask({
         question: text,
         documentId: index.state.documentId,
-        includeWebResearch,
-        useDeepSearch,
       });
     },
     [ask, index.state.documentId],
@@ -230,7 +220,7 @@ function EmptyState({ ready }: { ready: boolean }) {
         <p className="text-sm font-medium">Ask the document</p>
         <p className="text-xs text-muted-foreground max-w-[260px]">
           {ready
-            ? "Type a question about the loaded PDF. Toggle Web research or Deep search for richer answers."
+            ? "Type a question about the loaded PDF. Answers cite the pages they came from."
             : "Open a PDF to start indexing. Then ask away."}
         </p>
       </div>

--- a/desktop/src/hooks/useConfig.ts
+++ b/desktop/src/hooks/useConfig.ts
@@ -28,7 +28,8 @@ export interface ConfigResponse {
     pdf_cache_max_size_mb?: number;
   };
   rag: { enabled: boolean };
-  deep_search: Record<string, unknown>;
+  // No `deep_search` section: deep search / web research were removed in
+  // `35bca2c` and `AppSettings` has had no such field since.
   gui: Record<string, unknown>;
   processing?: {
     max_workers?: number;

--- a/desktop/src/hooks/useRagAsk.ts
+++ b/desktop/src/hooks/useRagAsk.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState } from "react";
 
 import { api } from "@/lib/api-client";
+import { buildAskBody } from "@/lib/ask-request";
 import { streamEvents } from "@/lib/sse";
 
 export interface ActionEvent {
@@ -49,8 +50,6 @@ let actionCounter = 0;
 interface AskParams {
   question: string;
   documentId: string | null;
-  includeWebResearch: boolean;
-  useDeepSearch: boolean;
 }
 
 export function useRagAsk() {
@@ -62,12 +61,10 @@ export function useRagAsk() {
 
     let jobId: string;
     try {
-      const accepted = await api.post<{ job_id: string }>("/rag/ask", {
-        question: params.question,
-        document_id: params.documentId,
-        include_web_research: params.includeWebResearch,
-        use_deep_search: params.useDeepSearch,
-      });
+      const accepted = await api.post<{ job_id: string }>(
+        "/rag/ask",
+        buildAskBody(params),
+      );
       jobId = accepted.job_id;
     } catch (e) {
       setState({ ...INITIAL, status: "error", error: (e as Error).message });

--- a/desktop/src/lib/ask-request.test.ts
+++ b/desktop/src/lib/ask-request.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { buildAskBody } from "./ask-request";
+
+describe("buildAskBody", () => {
+  it("sends the question and the document to scope it to", () => {
+    expect(
+      buildAskBody({ question: "What is the ablation?", documentId: "paper" }),
+    ).toEqual({ question: "What is the ablation?", document_id: "paper" });
+  });
+
+  it("keeps a null document — that means 'every indexed document'", () => {
+    expect(buildAskBody({ question: "hi", documentId: null })).toEqual({
+      question: "hi",
+      document_id: null,
+    });
+  });
+
+  // The regression this guards: `AskRequest` accepts `question`,
+  // `document_id` and `max_pdf_sources` and nothing else. Sending fields the
+  // schema doesn't declare is not an error — FastAPI drops them — so a toggle
+  // wired to one looks functional while doing nothing at all.
+  it("sends nothing the sidecar's AskRequest doesn't declare", () => {
+    const body = buildAskBody({ question: "hi", documentId: null });
+    expect(Object.keys(body).sort()).toEqual(["document_id", "question"]);
+    expect(body).not.toHaveProperty("include_web_research");
+    expect(body).not.toHaveProperty("use_deep_search");
+  });
+});

--- a/desktop/src/lib/ask-request.ts
+++ b/desktop/src/lib/ask-request.ts
@@ -1,0 +1,26 @@
+/**
+ * Building a `POST /rag/ask` request body.
+ *
+ * Small enough to inline, kept separate for the same reason as
+ * `translate-request.ts`: it's the one place the wire shape is decided, and
+ * the `node`-environment vitest suite can hold it to `api/schemas.py:AskRequest`.
+ *
+ * That drift is what this module exists to prevent. The chat input used to send
+ * `include_web_research` and `use_deep_search` alongside the question; deep
+ * search and web research were deleted in `35bca2c`, so `AskRequest` has no
+ * such fields and FastAPI dropped them silently — two toggles in the UI that
+ * changed nothing (#14).
+ */
+
+export interface AskBodyInput {
+  question: string;
+  /** `null` asks across every indexed document. */
+  documentId: string | null;
+}
+
+export function buildAskBody(input: AskBodyInput): Record<string, unknown> {
+  return {
+    question: input.question,
+    document_id: input.documentId,
+  };
+}


### PR DESCRIPTION
## Summary
Deletes the two chat toggles that have done nothing since `35bca2c`, and replaces the About dialog's three inaccurate claims (version, feature list, Docs link) with real ones.

## Root cause
Deep search / web research was removed from the backend in `35bca2c`, but the UI was left behind:

- `ChatInput` still rendered "Web research" and "Deep search" pills, the second with a tooltip promising "Multi-hop academic citation search (PubMed, arXiv, Semantic Scholar)".
- `useRagAsk` sent `include_web_research` / `use_deep_search` in the `POST /rag/ask` body. `api/schemas.py:AskRequest` declares neither, and **FastAPI ignores undeclared fields rather than rejecting them** — so nothing ever surfaced the mismatch. Both toggles were pure placebo.
- `AboutDialog` advertised "Deep multi-hop academic search", hard-coded `Version 0.2.0 — UI rewrite` (no such release; `tauri.conf.json` says `0.1.0`), and its Docs button linked to `github.com/anthropics/claude-code`.
- `ConfigResponse.deep_search` in `useConfig.ts` typed a config section `AppSettings` no longer has.

## Approach + alternatives rejected
- **Deleted rather than re-implemented.** The issue is filed as a bug, not a feature request, and re-implementing web research would mean new dependencies, new API surface and new failure modes for something the product deliberately dropped.
- **Moved the ask body into `lib/ask-request.ts`** instead of leaving the object literal inline. This is a deletion PR, and a deletion is hard to regression-test where it happened — but the *defect class* is testable: the reason nobody noticed was that an undeclared field is silently discarded. `buildAskBody` gives that contract a home and a test, mirroring `lib/translate-request.ts` (same shape, same reason, same suite). Three extra lines of indirection for a guard against the exact failure that produced this issue.
- **Version via the shell's `getVersion()`**, not a fresh hard-coded string and not the sidecar's `/health` version. `tauri.conf.json`'s `version` is what the .msi filename, the Programs list and the window's own metadata carry, so it's the number a user can read off their machine and quote in a bug report. It also means this file needs no edit when #25 unifies the four version numbers currently in the tree (`pyproject` 1.0.0, `tauri.conf.json`/`Cargo.toml`/`package.json` 0.1.0). Deliberately left #25's scope alone.
- **Kept `max_pdf_sources` off the wire.** `AskRequest` defaults it to 5 and no UI control sets it; sending a hard-coded 5 would just be another field to drift.

## Changes
- `desktop/src/components/chat/ChatInput.tsx` — toggles, their state, the tooltip imports and both icons removed; `onSubmit` is `{ text }`.
- `desktop/src/components/chat/ChatPanel.tsx` — `handleSubmit` follows; empty-state copy no longer tells users to toggle features that don't exist.
- `desktop/src/hooks/useRagAsk.ts` — `AskParams` trimmed; body built by `buildAskBody`.
- `desktop/src/lib/ask-request.ts` + `ask-request.test.ts` (new).
- `desktop/src/components/AboutDialog.tsx` — live version, accurate feature list (now naming Argos, the offline default, which the old list omitted entirely), Docs → this repo.
- `desktop/src/hooks/useConfig.ts` — `deep_search` removed from `ConfigResponse`.

## How tested
- `cd desktop && pnpm test` → 39 passed (3 new). The key test asserts the body has exactly `question` + `document_id` and neither dead field.
- `cd desktop && pnpm build` (tsc + vite) → clean; the `onSubmit` signature change is compile-enforced across `ChatInput` → `ChatPanel` → `useRagAsk`.
- `grep` over `desktop/src` and `src/` for `deep_search` / `web_research` / the camelCase forms → only the new comments and the regression assertions remain.
- Not exercised at runtime: the About dialog's `getVersion()` call needs the Tauri shell (`pnpm tauri dev`). It's guarded by `tauriAvailable()` and a `.catch`, and falls back to a tagline, so a failure can't blank the dialog.

## Risk + rollback
Low; UI-only, no backend change. The one behavioural change beyond deletion is the About version becoming async — worst case it shows the fallback tagline. Revert the commit to restore the toggles.

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss9ZsytfqdJiXHm77X8kC6
