### PR TITLE
fix: surface translator failures instead of caching a partial PDF

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,6 +297,46 @@ is on and the request didn't pass `bypass_cache=true`; the paragraph cache is
 gated by `settings.translation.cache_translations`. The "Re-translate" button in
 the UI sends `bypass_cache=true` (`hooks/useTranslation.ts`).
 
+What may be **written** to the PDF cache is a separate question, answered by
+`pdf_cache.py:is_cacheable_artifact`: the file must be a real
+`{stem}_translated_v*.pdf` in the job's own output dir, **and the run must have
+had zero failed paragraphs**. A cache entry is keyed by the input's hash, so a
+partly-untranslated artifact would be served on every later open of that file
+and stays invisible until someone clicks Re-translate.
+
+### Translator failures are counted, not swallowed
+
+`BaseTranslator._handle_translation_error` is the funnel every backend's
+`except` clause routes into, and it still returns the **source text** — raising
+would change nothing, because BabelDOC's `ILTranslator` catches whatever
+`translate()` raises and continues ("ignore error and continue"). So a bad key,
+a 429 or a network blip cannot fail a job on its own; the document just comes
+out partly untranslated while the pipeline reports success.
+
+Three things close that gap:
+
+- **Counting.** `BaseTranslator.failed_translations`, plus an
+  `on_translation_failed(error, fatal)` kwarg threaded through the same way as
+  `on_paragraph_translated`. `CompletionEvent` carries `failed_paragraphs` /
+  `total_paragraphs`, and the overlay says "N of M paragraphs could not be
+  translated" with a Retry (which is Re-translate — `bypass_cache=true`).
+- **Not caching such a run** (see `is_cacheable_artifact` above).
+- **Aborting on a fatal error.** `translators/base.py:is_fatal_translation_error`
+  classifies 401/403 (duck-typed on `status_code`/`code`/`.response`, with a
+  message fallback for google-genai, which carries the code only in its text).
+  On the first fatal failure `PDFProcessor._handle_translation_failure` pushes a
+  wake-up item onto the multiplexer queue — the loop is parked on
+  `events_queue.get()`, so without it the job would sit there while every
+  remaining paragraph made the same doomed call — and the loop raises
+  `TranslationProcessError`, which `_process_with_babeldoc` re-raises unwrapped
+  so its user-facing sentence survives.
+
+Relatedly, `PUT /config` **only auto-promotes `preferred_service` off Argos
+when the new key validates** (one provider round-trip, only on that path). An
+explicit `preferred_service` in the payload is always honoured — that's the
+user's own choice. Promoting on a typo'd key used to move the user from a
+working offline translator onto one that fails every paragraph silently.
+
 ### Translator plug-in interface (BabelDOC integration)
 
 BabelDOC drives chunking, layout, and PDF reassembly; it delegates the actual text translation to a translator object passed into `BabelDOCConfig(translator=...)` (see `processors/processor.py:364`). Two important facts about this seam:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,6 +313,17 @@ would change nothing, because BabelDOC's `ILTranslator` catches whatever
 a 429 or a network blip cannot fail a job on its own; the document just comes
 out partly untranslated while the pipeline reports success.
 
+**Every path that hands back source text goes through that funnel — including
+the ones that never raise.** That is the invariant a new backend has to
+preserve, and the one that was missed first time round: a bare `return text`
+is invisible to the counter, so the run still reports "complete" and still gets
+cached. The non-exception cases are "the provider returned nothing usable"
+(a Gemini safety filter drops `candidates` entirely; Anthropic/OpenAI can
+return empty content), and, in Argos, a failed `_ensure_en_vi_installed()`
+(the ~80 MB pack download — it raises for *every* paragraph, so an unguarded
+call meant a first run with no network produced a whole untranslated document
+that looked finished), a batch-wait timeout, and an empty result slot.
+
 Three things close that gap:
 
 - **Counting.** `BaseTranslator.failed_translations`, plus an
@@ -320,6 +331,11 @@ Three things close that gap:
   `on_paragraph_translated`. `CompletionEvent` carries `failed_paragraphs` /
   `total_paragraphs`, and the overlay says "N of M paragraphs could not be
   translated" with a Retry (which is Re-translate — `bypass_cache=true`).
+  The **M** is `translator.translate_call_count`, not the processor's
+  `_paragraphs_seen`: the latter is the live-ticker's counter and skips any
+  paragraph whose preview came out empty, which understates the denominator.
+  Both counters increment under `BaseTranslator._counter_lock` — one instance
+  serves BabelDOC's whole worker pool, and `+= 1` is a read-modify-write.
 - **Not caching such a run** (see `is_cacheable_artifact` above).
 - **Aborting on a fatal error.** `translators/base.py:is_fatal_translation_error`
   classifies 401/403 (duck-typed on `status_code`/`code`/`.response`, with a
@@ -331,11 +347,29 @@ Three things close that gap:
   `TranslationProcessError`, which `_process_with_babeldoc` re-raises unwrapped
   so its user-facing sentence survives.
 
+  The message-marker fallback names an **API key** specifically. Generic
+  phrases (`unauthorized`, `permission denied`) were tried and removed: a
+  provider that means them also sends 401/403, which the status check already
+  catches, while `PermissionError`/`OSError` carry "Permission denied" in their
+  text and would abort a run whose credentials were fine. Argos reaches this
+  path too (a 403 from the package index is fatal, and correctly so), which is
+  why the sentence comes from `base.py:describe_fatal_error` — it has no API
+  key, so the LLM wording would send the user to check a credential they never
+  set and to "switch to Argos" while already on it.
+
 Relatedly, `PUT /config` **only auto-promotes `preferred_service` off Argos
 when the new key validates** (one provider round-trip, only on that path). An
 explicit `preferred_service` in the payload is always honoured — that's the
 user's own choice. Promoting on a typo'd key used to move the user from a
 working offline translator onto one that fails every paragraph silently.
+
+Two things that probe has to keep: it runs under `_VALIDATE_PROBE_TIMEOUT_S`
+(Gemini's `validate_configuration` passes no timeout of its own, and this is
+the *save* path now, not just the Validate button), and a timeout reports the
+same "don't promote" as a rejection. The frontend's warning toast in
+`useConfig.ts` picks the provider to name using the **same priority order** the
+server promotes by — one PUT can carry several keys, and only the first is
+probed, so the two orders must not drift apart.
 
 ### Translator plug-in interface (BabelDOC integration)
 

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -150,6 +150,10 @@ function Workspace() {
           state={translation.state}
           onCancel={translation.cancel}
           onDismiss={translation.reset}
+          // Same path as the toolbar's Re-translate: a retry must skip the
+          // PDF cache, or a cached earlier result would be served instead of
+          // the re-run the user asked for.
+          onRetry={handleReTranslate}
         />
       </div>
 

--- a/desktop/src/components/translation/ProgressOverlay.tsx
+++ b/desktop/src/components/translation/ProgressOverlay.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { AnimatePresence, motion } from "motion/react";
-import { Clock, Loader2, X } from "lucide-react";
+import { AlertTriangle, Clock, Loader2, RotateCcw, X } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
@@ -12,6 +12,18 @@ interface ProgressOverlayProps {
   state: TranslationState;
   onCancel: () => void;
   onDismiss: () => void;
+  /** Re-run the translation, skipping the PDF cache. Offered when a run
+   *  finished with untranslated paragraphs, or failed outright. */
+  onRetry?: () => void;
+}
+
+function RetryButton({ onRetry }: { onRetry: () => void }) {
+  return (
+    <Button size="sm" variant="outline" onClick={onRetry}>
+      <RotateCcw className="mr-1.5 h-3.5 w-3.5" />
+      Retry translation
+    </Button>
+  );
 }
 
 function formatEta(seconds: number): string {
@@ -52,6 +64,7 @@ export function ProgressOverlay({
   state,
   onCancel,
   onDismiss,
+  onRetry,
 }: ProgressOverlayProps) {
   const chunkProgress = useAppStore((s) => s.chunkProgress);
   const exportedPath = useAppStore((s) => s.exportedPdfPath);
@@ -63,6 +76,11 @@ export function ProgressOverlay({
   if (state.status === "idle") return null;
 
   const busy = isTranslationBusy(state);
+  // A "complete" run can still be partly the source document: the translator
+  // falls back to source text on any error and BabelDOC carries on. The count
+  // is the only evidence, so it gets said out loud.
+  const failed = state.failedParagraphs ?? 0;
+  const partial = state.status === "done" && failed > 0;
   const pagesLeft =
     chunkProgress && chunkProgress.totalChunks > 0
       ? chunkProgress.totalChunks - chunkProgress.chunksReady
@@ -88,7 +106,8 @@ export function ProgressOverlay({
               <Loader2 className="h-4 w-4 shrink-0 animate-spin text-primary" />
             )}
             <span className="truncate text-sm font-medium">
-              {state.status === "done" && "Translation complete"}
+              {state.status === "done" &&
+                (partial ? "Translation incomplete" : "Translation complete")}
               {state.status === "error" && "Translation failed"}
               {state.status === "cancelled" && "Translation cancelled"}
               {state.status === "cancelling" && "Cancelling…"}
@@ -173,7 +192,24 @@ export function ProgressOverlay({
           </>
         )}
         {state.status === "error" && state.error && (
-          <p className="text-xs text-destructive">{state.error}</p>
+          <div className="space-y-2.5">
+            <p className="text-xs text-destructive">{state.error}</p>
+            {onRetry && <RetryButton onRetry={onRetry} />}
+          </div>
+        )}
+        {partial && (
+          <div className="mb-2.5 space-y-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-2.5">
+            <p className="flex items-start gap-1.5 text-xs text-amber-700 dark:text-amber-500">
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <span>
+                {failed} of {state.totalParagraphs ?? failed} paragraph
+                {failed === 1 ? "" : "s"} could not be translated and are still
+                in the source language. This result was not cached — retrying
+                runs them again.
+              </span>
+            </p>
+            {onRetry && <RetryButton onRetry={onRetry} />}
+          </div>
         )}
         {(state.status === "done" || state.status === "cancelled") &&
           resultPath && (

--- a/desktop/src/hooks/useConfig.ts
+++ b/desktop/src/hooks/useConfig.ts
@@ -121,7 +121,10 @@ export function useUpdateConfig() {
       // …and the server only promotes on a key that *validates*. When it
       // doesn't, the save still succeeds but nothing visible changes — which
       // reads as "my key was accepted" for a key the provider just rejected.
-      const savedKeyFor = (["openai", "gemini", "anthropic"] as const).find(
+      // Same priority the server promotes by (`routes/config.py`): one PUT
+      // can carry keys for several services, and only the first by this order
+      // is probed — so a different order here would name the wrong provider.
+      const savedKeyFor = (["openai", "anthropic", "gemini"] as const).find(
         (code) => update[code]?.api_key,
       );
       if (

--- a/desktop/src/hooks/useConfig.ts
+++ b/desktop/src/hooks/useConfig.ts
@@ -97,9 +97,14 @@ export function useUpdateConfig() {
   return useMutation({
     mutationFn: (update: ConfigUpdate) =>
       api.put<ConfigResponse>("/config", update),
-    onSuccess: (data) => {
+    onSuccess: (data, update) => {
       const previous = qc.getQueryData<ConfigResponse>(["config"]);
       qc.setQueryData(["config"], data);
+
+      const label = (code: string) => {
+        const options = qc.getQueryData<OptionsResponse>(["config", "options"]);
+        return options?.services.find((s) => s.code === code)?.label ?? code;
+      };
 
       // Server may auto-promote preferred_service from "argos" to an LLM
       // when the user just saved a key. Surface that to the user.
@@ -108,12 +113,25 @@ export function useUpdateConfig() {
         previous.translation.preferred_service !==
           data.translation.preferred_service
       ) {
-        const options = qc.getQueryData<OptionsResponse>(["config", "options"]);
-        const label =
-          options?.services.find(
-            (s) => s.code === data.translation.preferred_service,
-          )?.label ?? data.translation.preferred_service;
-        toast.success(`Switched to ${label}`);
+        toast.success(`Switched to ${label(data.translation.preferred_service)}`);
+        return;
+      }
+
+      // …and the server only promotes on a key that *validates*. When it
+      // doesn't, the save still succeeds but nothing visible changes — which
+      // reads as "my key was accepted" for a key the provider just rejected.
+      const savedKeyFor = (["openai", "gemini", "anthropic"] as const).find(
+        (code) => update[code]?.api_key,
+      );
+      if (
+        savedKeyFor &&
+        previous?.translation.preferred_service === "argos" &&
+        data.translation.preferred_service === "argos"
+      ) {
+        toast.warning(`${label(savedKeyFor)} did not accept that key`, {
+          description:
+            "The key is saved, but translation stays on Argos (offline). Use Validate to check it.",
+        });
       }
     },
   });

--- a/desktop/src/hooks/useTranslation.ts
+++ b/desktop/src/hooks/useTranslation.ts
@@ -25,6 +25,11 @@ interface CompletionPayload {
   /** Language the run actually produced, straight from the processor. Names
    *  the default file in the Save dialog — see `translationTargetLang`. */
   target_lang?: string | null;
+  /** Paragraphs handed back as source text because the translator errored.
+   *  BabelDOC swallows those errors, so this count is the only evidence that
+   *  a "complete" translation is partly the original document. */
+  failed_paragraphs?: number;
+  total_paragraphs?: number;
 }
 
 interface ChunkReadyPayload {
@@ -59,6 +64,11 @@ export interface TranslationState {
   message: string;
   error?: string;
   translatedPath?: string | null;
+  /** Non-zero means the finished PDF is only partly translated — those
+   *  paragraphs are still in the source language. Such a run is deliberately
+   *  not cached, so Re-translate can produce a better one. */
+  failedParagraphs?: number;
+  totalParagraphs?: number;
   /** Server-reported ETA at the moment of the last chunk_ready, in seconds.
    *  Frontend smooth-decays this between updates. */
   etaSeconds?: number | null;
@@ -270,6 +280,8 @@ export function useTranslation() {
                 progress: 100,
                 stage: c.cache_hit ? "Loaded from cache" : "Done",
                 translatedPath: c.translated_file ?? null,
+                failedParagraphs: c.failed_paragraphs ?? 0,
+                totalParagraphs: c.total_paragraphs ?? 0,
               }));
             } else if (type === "cancelled") {
               const c = data as CompletionPayload;

--- a/src/desktop_pdf_translator/api/routes/config.py
+++ b/src/desktop_pdf_translator/api/routes/config.py
@@ -37,6 +37,32 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/config", tags=["config"], dependencies=[Depends(require_token)])
 
 
+async def _credentials_work(
+    service: TranslationService, service_config: dict
+) -> tuple[bool, str]:
+    """Probe a just-saved key the same way `POST /config/validate` does.
+
+    Runs off the event loop — `validate_configuration()` is a blocking HTTP
+    call to the provider.
+    """
+
+    def probe() -> tuple[bool, str]:
+        kwargs = {"api_key": service_config.get("api_key")}
+        # Only override the model when we have one: passing `model=None`
+        # replaces the backend's own default with None.
+        if service_config.get("model"):
+            kwargs["model"] = service_config["model"]
+        translator = TranslatorFactory.create_translator(
+            service=service, lang_in="en", lang_out="vi", **kwargs
+        )
+        return translator.validate_configuration()
+
+    try:
+        return await asyncio.to_thread(probe)
+    except Exception as exc:  # noqa: BLE001 — any failure means "don't promote"
+        return False, str(exc)
+
+
 def _mask(service_settings) -> APIKeyMaskedSettings:
     # ArgosSettings has no api_key attribute, so getattr falls through to False.
     return APIKeyMaskedSettings(
@@ -90,6 +116,7 @@ async def update_config(payload: ConfigUpdateRequest) -> ConfigResponse:
             current[service.value]["model"] = update.model
 
     if payload.preferred_service is not None:
+        # An explicit choice is the user's to make — honoured unconditionally.
         current["translation"]["preferred_service"] = payload.preferred_service.value
     elif (
         current["translation"].get("preferred_service") == TranslationService.ARGOS.value
@@ -101,11 +128,25 @@ async def update_config(payload: ConfigUpdateRequest) -> ConfigResponse:
             TranslationService.GEMINI,
         )
         chosen = next((s for s in priority if s in newly_keyed), newly_keyed[0])
-        current["translation"]["preferred_service"] = chosen.value
-        logger.info(
-            "Auto-switching preferred_service argos -> %s after key save",
-            chosen.value,
-        )
+        # Promote only on a key that actually works. Moving the user off Argos
+        # on a typo'd key used to hand them a translator that fails every
+        # paragraph, silently, for every document from then on — while Argos
+        # would have kept working. One provider round-trip, and only on the
+        # rare "first key saved while still on Argos" path.
+        ok, message = await _credentials_work(chosen, current[chosen.value])
+        if ok:
+            current["translation"]["preferred_service"] = chosen.value
+            logger.info(
+                "Auto-switching preferred_service argos -> %s after key save",
+                chosen.value,
+            )
+        else:
+            logger.warning(
+                "Key saved for %s but it did not validate (%s) — staying on "
+                "Argos. The user can still switch services explicitly.",
+                chosen.value,
+                message,
+            )
 
     if payload.default_source_lang is not None:
         current["translation"]["default_source_lang"] = payload.default_source_lang.value

--- a/src/desktop_pdf_translator/api/routes/config.py
+++ b/src/desktop_pdf_translator/api/routes/config.py
@@ -37,13 +37,25 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/config", tags=["config"], dependencies=[Depends(require_token)])
 
 
+# Deadline for the auto-promotion probe below. Generous enough for a cold
+# TLS handshake to a provider, short enough that Settings → Save still feels
+# like a save.
+_VALIDATE_PROBE_TIMEOUT_S = 20.0
+
+
 async def _credentials_work(
     service: TranslationService, service_config: dict
 ) -> tuple[bool, str]:
     """Probe a just-saved key the same way `POST /config/validate` does.
 
     Runs off the event loop — `validate_configuration()` is a blocking HTTP
-    call to the provider.
+    call to the provider — and under a deadline, because this sits on the
+    Settings *save* path now, not just behind the Validate button. OpenAI and
+    Anthropic pass their own `timeout=10`; Gemini passes none, so without this
+    a save on a flaky connection would hang for the SDK's default.
+
+    A timeout reports the same thing as a rejection: don't promote. The key is
+    still saved, and the user can switch services explicitly.
     """
 
     def probe() -> tuple[bool, str]:
@@ -58,7 +70,12 @@ async def _credentials_work(
         return translator.validate_configuration()
 
     try:
-        return await asyncio.to_thread(probe)
+        return await asyncio.wait_for(
+            asyncio.to_thread(probe), timeout=_VALIDATE_PROBE_TIMEOUT_S
+        )
+    except (asyncio.TimeoutError, TimeoutError):
+        # The thread is left to finish on its own; nothing reads its result.
+        return False, f"timed out contacting {service.value}"
     except Exception as exc:  # noqa: BLE001 — any failure means "don't promote"
         return False, str(exc)
 

--- a/src/desktop_pdf_translator/processors/events.py
+++ b/src/desktop_pdf_translator/processors/events.py
@@ -157,6 +157,12 @@ class CompletionEvent(ProcessingEvent):
     # rather than from its own config copy, which the user can change after
     # the run finishes.
     target_lang: Optional[str] = None
+    # Paragraphs the translator could not translate and handed back as source
+    # text. BabelDOC ignores translator errors and carries on, so a non-zero
+    # count is the *only* signal that a "complete" PDF is partly untranslated.
+    # Such a run is never written to the PDF cache.
+    failed_paragraphs: int = 0
+    total_paragraphs: int = 0
 
     def __post_init__(self):
         """Initialize event data from attributes."""
@@ -169,4 +175,6 @@ class CompletionEvent(ProcessingEvent):
             "cache_hit": self.cache_hit,
             "cached_at": self.cached_at,
             "target_lang": self.target_lang,
+            "failed_paragraphs": self.failed_paragraphs,
+            "total_paragraphs": self.total_paragraphs,
         }

--- a/src/desktop_pdf_translator/processors/pdf_cache.py
+++ b/src/desktop_pdf_translator/processors/pdf_cache.py
@@ -81,6 +81,40 @@ def _make_cache_key(
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
+def is_cacheable_artifact(
+    translated_file: Optional[Path],
+    output_dir: Path,
+    input_stem: str,
+    failed_paragraphs: int = 0,
+) -> bool:
+    """Whether a finished run may be written to the cache.
+
+    A cache entry is keyed by the input's hash, so a bad one is served for
+    every later open of that file and is invisible until someone thinks to
+    click Re-translate. Two ways a run earns a `False`:
+
+    * **The artifact isn't ours.** `_find_translated_file` has broad fallbacks
+      (newest `*.pdf` in `output_dir`) that can return an unrelated PDF when
+      BabelDOC produced no rolling output. Only `{stem}_translated_v*.pdf`
+      directly inside `output_dir` counts.
+    * **Paragraphs failed.** `_handle_translation_error` hands back source
+      text on any error and BabelDOC carries on, so a rejected key, a 429 or a
+      network blip yields a full-length, partly-untranslated PDF that looks
+      finished. Storing that pins the bad result to the input's hash.
+
+    Lives here rather than in `processor.py` so the rule is next to the cache
+    it guards, and so the test suite can exercise it without importing
+    BabelDOC.
+    """
+    if translated_file is None or failed_paragraphs > 0:
+        return False
+    return (
+        translated_file.parent == output_dir
+        and translated_file.name.startswith(f"{input_stem}_translated_v")
+        and translated_file.suffix.lower() == ".pdf"
+    )
+
+
 @dataclass
 class CacheHit:
     cached_path: Path

--- a/src/desktop_pdf_translator/processors/processor.py
+++ b/src/desktop_pdf_translator/processors/processor.py
@@ -22,6 +22,7 @@ from babeldoc.format.pdf.translation_config import WatermarkOutputMode as BabelD
 from ..config import get_settings, FileMetadata, LanguageCode, TranslationService
 from ..translators import TranslatorFactory
 from ..translators.argos_translator import ArgosTranslator
+from ..translators.base import describe_fatal_error
 from ..translators.capabilities import resolve_effective_service, resolve_languages
 from .events import (
     ProcessingEvent,
@@ -602,7 +603,15 @@ class PDFProcessor:
                 pages_processed=file_metadata.page_count,
                 target_lang=target_lang.value,
                 failed_paragraphs=self._failed_paragraphs,
-                total_paragraphs=self._paragraphs_seen + self._failed_paragraphs,
+                # The translator's own call count, not `_paragraphs_seen`:
+                # the latter is the ticker's counter and skips any paragraph
+                # whose preview came out empty, which would understate the
+                # denominator of "N of M could not be translated". One
+                # translator instance serves every chunk, so this is a
+                # whole-document total.
+                total_paragraphs=max(
+                    translator.translate_call_count, self._failed_paragraphs
+                ),
             )
             
         except ProcessingError as e:
@@ -1126,9 +1135,8 @@ class PDFProcessor:
             self._failed_paragraphs += 1
             if not fatal or self._fatal_translation_error is not None:
                 return
-            self._fatal_translation_error = (
-                f"{self._service_name} rejected the request: {error}. "
-                "Check the API key in Settings, or switch to Argos (offline)."
+            self._fatal_translation_error = describe_fatal_error(
+                self._service_name, error
             )
         loop, queue = self._event_loop, self._events_queue
         if loop is None or queue is None:

--- a/src/desktop_pdf_translator/processors/processor.py
+++ b/src/desktop_pdf_translator/processors/processor.py
@@ -7,6 +7,7 @@ import logging
 import os
 import shutil
 import tempfile
+import threading
 import time
 import uuid
 from pathlib import Path
@@ -31,8 +32,14 @@ from .events import (
     ParagraphTranslatedEvent,
     EventType,
 )
-from .pdf_cache import compute_file_hash, get_pdf_cache
-from .exceptions import ProcessingError, BabelDOCError, FileValidationError, ConfigurationError
+from .pdf_cache import compute_file_hash, get_pdf_cache, is_cacheable_artifact
+from .exceptions import (
+    ProcessingError,
+    BabelDOCError,
+    FileValidationError,
+    ConfigurationError,
+    TranslationProcessError,
+)
 
 
 # Background PDF-cache store tasks. The processor schedules store() off the
@@ -134,6 +141,10 @@ _MAX_PARALLEL_CHUNKS_ARGOS = 2
 # but improve pipeline depth. 4 is a reasonable default for desktop machines.
 _MAX_PARALLEL_CHUNKS = 4
 
+# Tag for the "stop now, the credentials are being rejected" item that
+# `_handle_translation_failure` pushes onto the multiplexer queue.
+_FATAL_KIND = "fatal"
+
 
 def _effective_parallel_chunks(settings, translator=None) -> int:
     """Resolve the chunk-concurrency knob.
@@ -205,6 +216,15 @@ class PDFProcessor:
         self._event_loop: Optional[asyncio.AbstractEventLoop] = None
         self._paragraphs_seen: int = 0
         self._service_name: str = "argos"
+        # Failure accounting. `_handle_translation_failure` runs on BabelDOC's
+        # worker threads — several at once — so the counter and the
+        # "already reported" latch are both taken under a lock: `+= 1` is a
+        # read-modify-write that can drop increments, and an unguarded
+        # check-then-set would let two threads each raise the abort.
+        self._failure_lock = threading.Lock()
+        self._failed_paragraphs: int = 0
+        self._fatal_translation_error: Optional[str] = None
+        self._events_queue: Optional[asyncio.Queue] = None
     
     async def process_pdf(
         self,
@@ -463,6 +483,8 @@ class PDFProcessor:
             self._paragraph_queue = asyncio.Queue(maxsize=64)
             self._event_loop = asyncio.get_running_loop()
             self._paragraphs_seen = 0
+            self._failed_paragraphs = 0
+            self._fatal_translation_error = None
             self._service_name = translation_service.value
 
             translator = TranslatorFactory.create_translator(
@@ -470,6 +492,7 @@ class PDFProcessor:
                 lang_in=source_lang,
                 lang_out=target_lang,
                 on_paragraph_translated=self._handle_paragraph,
+                on_translation_failed=self._handle_translation_failure,
             )
             
             yield ProgressEvent(
@@ -517,18 +540,16 @@ class PDFProcessor:
             # worker thread because store() hashes the input and copies the
             # output — both blocking. Errors are non-fatal.
             #
-            # IMPORTANT: only cache when `translated_file` is a real rolling
-            # output (`{stem}_translated_v*.pdf`). `_find_translated_file` has
-            # broad fallbacks (newest `*.pdf` in `output_dir`) that can return
-            # an unrelated stale PDF if BabelDOC silently produced no rolling
-            # files. Caching that would permanently bind a wrong translation
-            # to the input's hash, undetectable without a manual clear.
-            should_cache = (
-                translated_file
-                and self.settings.translation.cache_translated_pdfs
-                and translated_file.parent == output_dir
-                and translated_file.name.startswith(f"{file_path.stem}_translated_v")
-                and translated_file.suffix.lower() == ".pdf"
+            # What may be cached at all is `is_cacheable_artifact`'s call: the
+            # file must be a real rolling output, and no paragraph may have
+            # failed. Both rules live next to the cache they guard.
+            should_cache = self.settings.translation.cache_translated_pdfs and (
+                is_cacheable_artifact(
+                    translated_file,
+                    output_dir,
+                    file_path.stem,
+                    self._failed_paragraphs,
+                )
             )
             if should_cache:
                 # Fire-and-forget: don't block CompletionEvent on store(). The
@@ -553,12 +574,20 @@ class PDFProcessor:
                 store_task.add_done_callback(_pending_cache_writes.discard)
                 store_task.add_done_callback(_log_cache_store_failure)
             elif translated_file and self.settings.translation.cache_translated_pdfs:
-                logger.warning(
-                    "Skipping PDF cache store: translated_file %s is not a "
-                    "rolling output for stem %r — would risk caching a "
-                    "stale/unrelated PDF",
-                    translated_file, file_path.stem,
-                )
+                if self._failed_paragraphs:
+                    logger.warning(
+                        "Skipping PDF cache store: %d paragraph(s) fell back to "
+                        "source text, so this artifact is only partially "
+                        "translated",
+                        self._failed_paragraphs,
+                    )
+                else:
+                    logger.warning(
+                        "Skipping PDF cache store: translated_file %s is not a "
+                        "rolling output for stem %r — would risk caching a "
+                        "stale/unrelated PDF",
+                        translated_file, file_path.stem,
+                    )
 
             yield CompletionEvent(
                 type=EventType.FINISH,
@@ -571,6 +600,8 @@ class PDFProcessor:
                 processing_time_seconds=processing_time,
                 pages_processed=file_metadata.page_count,
                 target_lang=target_lang.value,
+                failed_paragraphs=self._failed_paragraphs,
+                total_paragraphs=self._paragraphs_seen + self._failed_paragraphs,
             )
             
         except ProcessingError as e:
@@ -835,6 +866,9 @@ class PDFProcessor:
             # generator drains it and yields events in arrival order until
             # the chunk-completion task signals done via `None`.
             events_queue: asyncio.Queue = asyncio.Queue()
+            # Published so `_handle_translation_failure` — which runs on
+            # BabelDOC's worker threads — can wake this loop on a fatal error.
+            self._events_queue = events_queue
             _SENTINEL = object()
             chunk_weight = 40.0 / total_chunks
 
@@ -886,6 +920,15 @@ class PDFProcessor:
                     if event is _SENTINEL:
                         break
                     kind = event[0]
+                    if kind == _FATAL_KIND:
+                        # A rejected key. BabelDOC swallows translator errors
+                        # and carries on, so nothing else would stop this run
+                        # before it produced — and cached — an untranslated PDF.
+                        raise TranslationProcessError(
+                            self._fatal_translation_error
+                            or "Translation service rejected the request",
+                            translator_name=self._service_name,
+                        )
                     if kind == "paragraph":
                         _, s, t = event
                         yield ParagraphTranslatedEvent(
@@ -985,12 +1028,16 @@ class PDFProcessor:
                 message="All pages translated",
             )
 
-        except BabelDOCError:
+        except (BabelDOCError, TranslationProcessError):
+            # TranslationProcessError already carries a sentence written for
+            # the user — wrapping it in "BabelDOC processing error: …" would
+            # bury it.
             raise
         except Exception as e:
             logger.exception(f"BabelDOC processing error: {e}")
             raise BabelDOCError(f"BabelDOC processing error: {e}", original_error=e)
         finally:
+            self._events_queue = None
             # On error, cancel, or normal exit: ensure no worker task is left
             # running. asyncio.gather with return_exceptions consumes any
             # CancelledError so it doesn't propagate out of the cleanup.
@@ -1048,6 +1095,35 @@ class PDFProcessor:
             self._event_loop.call_soon_threadsafe(self._enqueue_paragraph, (s, t))
         except RuntimeError:
             # Loop shutting down; drop silently.
+            pass
+
+    def _handle_translation_failure(
+        self, error: BaseException, fatal: bool
+    ) -> None:
+        """Thread-safe failure callback, wired into every translator.
+
+        Counts the paragraph, and on the first *fatal* failure (a rejected
+        key) wakes the event multiplexer so the job stops now. Without that
+        wake the loop would sit on `events_queue.get()` while the remaining
+        paragraphs each made the same doomed API call — minutes of billing
+        and waiting for a document that will come out untranslated.
+        """
+        with self._failure_lock:
+            self._failed_paragraphs += 1
+            if not fatal or self._fatal_translation_error is not None:
+                return
+            self._fatal_translation_error = (
+                f"{self._service_name} rejected the request: {error}. "
+                "Check the API key in Settings, or switch to Argos (offline)."
+            )
+        loop, queue = self._event_loop, self._events_queue
+        if loop is None or queue is None:
+            return
+        try:
+            loop.call_soon_threadsafe(queue.put_nowait, (_FATAL_KIND,))
+        except RuntimeError:
+            # Loop shutting down — nothing left to wake. The count still
+            # stands, so the run stays out of the PDF cache either way.
             pass
 
     def _enqueue_paragraph(self, payload: tuple[str, str]) -> None:

--- a/src/desktop_pdf_translator/translators/anthropic_translator.py
+++ b/src/desktop_pdf_translator/translators/anthropic_translator.py
@@ -48,7 +48,7 @@ class AnthropicTranslator(BaseTranslator):
         logger.info(f"Anthropic translator configured with model: {self.model}")
 
     def translate(self, text: str, **kwargs) -> str:
-        self.translate_call_count += 1
+        self._note_translate_call()
 
         try:
             processed_text = self._preprocess_text(text)
@@ -76,8 +76,13 @@ class AnthropicTranslator(BaseTranslator):
             ).strip()
 
             if not translated_text:
-                logger.warning("Anthropic response was empty")
-                return text
+                # Same as any other failed paragraph — see the funnel in
+                # base.py. Returning bare source text here left it uncounted
+                # and the run cacheable.
+                return self._handle_translation_error(
+                    RuntimeError("Anthropic returned an empty translation"),
+                    text,
+                )
 
             result = self._postprocess_text(translated_text)
             _llm_cache_set(processed_text, result, self.lang_in, self.lang_out, "anthropic", self.model)

--- a/src/desktop_pdf_translator/translators/argos_translator.py
+++ b/src/desktop_pdf_translator/translators/argos_translator.py
@@ -353,7 +353,7 @@ class ArgosTranslator(BaseTranslator):
         )
 
     def translate(self, text: str, **kwargs) -> str:
-        self.translate_call_count += 1
+        self._note_translate_call()
 
         # Step 1 — raw input handed to translate().
         _debug.record(
@@ -403,7 +403,16 @@ class ArgosTranslator(BaseTranslator):
         # blocks inside _ensure_en_vi_installed while other threads pile
         # additional paragraphs into the queue and the tail-timer may fire
         # against an unfinished install.
-        _ensure_en_vi_installed()
+        #
+        # This raises on any network problem (update_package_index, download)
+        # and it raises for *every* paragraph, so leaving it unguarded meant a
+        # first run with no network produced a fully-untranslated PDF that
+        # reported success and was cached against the input's hash. Routing it
+        # through the funnel is what keeps such a run out of the PDF cache.
+        try:
+            _ensure_en_vi_installed()
+        except Exception as e:  # noqa: BLE001 — counted, then falls back
+            return self._handle_translation_error(e, text)
 
         event = threading.Event()
         result_slot: list[str | None] = [None]
@@ -446,17 +455,21 @@ class ArgosTranslator(BaseTranslator):
         # remains; the timeout is generous. On timeout we fall back to the
         # original text — a late event.set() on this abandoned entry is harmless.
         if not event.wait(timeout=_BATCH_WAIT_TIMEOUT):
-            logger.warning(
-                "Argos batch wait timed out after %.0fs (call #%d); returning "
-                "original text as fallback.",
-                _BATCH_WAIT_TIMEOUT,
-                self.translate_call_count,
+            return self._handle_translation_error(
+                TimeoutError(
+                    f"Argos batch wait timed out after "
+                    f"{_BATCH_WAIT_TIMEOUT:.0f}s"
+                ),
+                text,
             )
-            return text
         result = result_slot[0]
         # Slot can still be None if the event fired without a result assigned
         # (shouldn't happen — every path sets it — but guard defensively).
-        return result if result is not None else text
+        if result is None:
+            return self._handle_translation_error(
+                RuntimeError("Argos batch worker fired without a result"), text
+            )
+        return result
 
     def _cancel_timer_locked(self) -> None:
         """Cancel any armed tail-flush timer. Caller must hold _batch_lock."""

--- a/src/desktop_pdf_translator/translators/base.py
+++ b/src/desktop_pdf_translator/translators/base.py
@@ -4,6 +4,7 @@ Base translator interface compatible with BabelDOC.
 
 import logging
 import re
+import threading
 from abc import ABC, abstractmethod
 from typing import Dict, Optional, Any
 
@@ -21,6 +22,59 @@ LANGUAGE_DISPLAY_NAMES: Dict[str, str] = {
     "zh-tw": "Traditional Chinese (繁體中文)",
     "auto": "automatically detected language",
 }
+
+
+# Statuses that mean the credentials are wrong, not that the request was
+# unlucky. Every remaining paragraph will fail identically, so the job should
+# stop rather than quietly emit a source-text copy of the document.
+_FATAL_STATUS_CODES = frozenset({401, 403})
+
+# Fallback for SDK wrappers that don't expose a status: google-genai's
+# ClientError, for one, puts the code in its message. Matched against
+# `str(error)` — the exception's own text, never the document's.
+_FATAL_MESSAGE_MARKERS = (
+    "invalid_api_key",
+    "invalid api key",
+    "incorrect api key",
+    "api key not valid",
+    "unauthorized",
+    "permission denied",
+    "permission_denied",
+    "authenticationerror",
+)
+
+
+def _status_code_of(error: BaseException) -> Optional[int]:
+    """Best-effort HTTP status for an SDK exception.
+
+    Duck-typed on purpose: this module must stay importable without the
+    OpenAI / Anthropic / google-genai packages installed, so the exception
+    classes can't be referenced by name. All three expose the status either
+    directly or on a `.response`.
+    """
+    for attr in ("status_code", "code", "http_status"):
+        value = getattr(error, attr, None)
+        if isinstance(value, bool):  # bool is an int subclass — never a status
+            continue
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str) and value.isdigit():
+            return int(value)
+    status = getattr(getattr(error, "response", None), "status_code", None)
+    return status if isinstance(status, int) else None
+
+
+def is_fatal_translation_error(error: BaseException) -> bool:
+    """Whether this failure means every later paragraph will fail the same way.
+
+    A rejected key is the case that matters: BabelDOC logs and continues on a
+    translator error, so without this a bad key produces a full-length,
+    fully-untranslated PDF that reports success.
+    """
+    if _status_code_of(error) in _FATAL_STATUS_CODES:
+        return True
+    message = str(error).lower()
+    return any(marker in message for marker in _FATAL_MESSAGE_MARKERS)
 
 
 class BaseTranslator(ABC):
@@ -46,17 +100,33 @@ class BaseTranslator(ABC):
                     each paragraph is translated. Receives (source, target).
                     Used by the processor to emit `paragraph_translated`
                     SSE events for the live ticker UI.
+                  on_translation_failed: Optional[Callable[[BaseException, bool], None]]
+                    Fired on the same threads when a paragraph could not be
+                    translated. Receives (error, fatal), where `fatal` marks a
+                    failure that will repeat for every remaining paragraph
+                    (see `is_fatal_translation_error`). The processor counts
+                    these and aborts the job on a fatal one.
         """
         self.lang_in = self._normalize_language_code(lang_in)
         self.lang_out = self._normalize_language_code(lang_out)
         self.translate_call_count = 0
+        # Paragraphs this instance handed back untranslated. Read by the
+        # processor to decide whether the run is cacheable and what to tell
+        # the user; the translator itself never acts on it.
+        #
+        # One instance is shared across BabelDOC's whole worker pool, so the
+        # increment is locked — `+= 1` is a read-modify-write and would drop
+        # counts under exactly the concurrent failures this exists to measure.
+        self._failure_lock = threading.Lock()
+        self.failed_translations = 0
 
-        # Pop the cross-cutting callback before passing the rest to the
-        # subclass setup so backends don't need to thread it through their
+        # Pop the cross-cutting callbacks before passing the rest to the
+        # subclass setup so backends don't need to thread them through their
         # own kwargs handling.
         self._on_paragraph_translated = kwargs.pop(
             "on_paragraph_translated", None
         )
+        self._on_translation_failed = kwargs.pop("on_translation_failed", None)
 
         # Initialize translator-specific settings
         self._setup_translator(**kwargs)
@@ -74,6 +144,17 @@ class BaseTranslator(ABC):
             cb(source, target)
         except Exception:
             logger.debug("on_paragraph_translated callback raised", exc_info=True)
+
+    def _fire_failure_callback(self, error: BaseException, fatal: bool) -> None:
+        """Best-effort: report a failed paragraph. Same contract as
+        `_fire_paragraph_callback` — a UI hook must never break a run."""
+        cb = self._on_translation_failed
+        if cb is None:
+            return
+        try:
+            cb(error, fatal)
+        except Exception:
+            logger.debug("on_translation_failed callback raised", exc_info=True)
     
     def _normalize_language_code(self, lang_code: str) -> str:
         """Normalize language code for translator compatibility."""
@@ -196,9 +277,29 @@ class BaseTranslator(ABC):
         return text
     
     def _handle_translation_error(self, error: Exception, text: str) -> str:
-        """Handle translation errors gracefully."""
-        logger.error(f"Translation failed for text: {text[:100]}..., Error: {error}")
-        
+        """Record a failed paragraph and fall back to its source text.
+
+        The fallback stays: BabelDOC's `ILTranslator` catches whatever
+        `translate()` raises and continues anyway, so raising here would only
+        lose the paragraph's text without stopping anything. What changes is
+        that the failure is now *counted* and *reported* — the processor uses
+        that to refuse caching the result, to tell the user how much of the
+        document is untranslated, and to abort outright on a rejected key.
+        """
+        with self._failure_lock:
+            self.failed_translations += 1
+            failure_number = self.failed_translations
+        fatal = is_fatal_translation_error(error)
+        logger.error(
+            "Translation failed (%s#%d, fatal=%s) for text: %s..., Error: %s",
+            self.__class__.__name__,
+            failure_number,
+            fatal,
+            text[:100],
+            error,
+        )
+        self._fire_failure_callback(error, fatal)
+
         # Return original text as fallback
         return text
     

--- a/src/desktop_pdf_translator/translators/base.py
+++ b/src/desktop_pdf_translator/translators/base.py
@@ -32,14 +32,18 @@ _FATAL_STATUS_CODES = frozenset({401, 403})
 # Fallback for SDK wrappers that don't expose a status: google-genai's
 # ClientError, for one, puts the code in its message. Matched against
 # `str(error)` — the exception's own text, never the document's.
+#
+# Every marker here names an API key specifically. Generic phrases like
+# "unauthorized" or "permission denied" were tried and removed: a provider
+# that means them also sends 401/403, which `_status_code_of` already catches,
+# while `PermissionError`/`OSError` — a Windows file lock on the CTranslate2
+# model, say — carry "Permission denied" in their text and would abort a run
+# that had nothing wrong with its credentials.
 _FATAL_MESSAGE_MARKERS = (
     "invalid_api_key",
     "invalid api key",
     "incorrect api key",
     "api key not valid",
-    "unauthorized",
-    "permission denied",
-    "permission_denied",
     "authenticationerror",
 )
 
@@ -77,6 +81,27 @@ def is_fatal_translation_error(error: BaseException) -> bool:
     return any(marker in message for marker in _FATAL_MESSAGE_MARKERS)
 
 
+def describe_fatal_error(service_name: str, error: BaseException) -> str:
+    """The sentence the user sees when a fatal failure stops a job.
+
+    Argos gets its own wording. It is a fatal path — a blocked package index
+    returns 403 from `_ensure_en_vi_installed`, which fails every paragraph
+    identically — but it has no API key, so the LLM sentence would tell the
+    user to check a credential they never set and to "switch to Argos" while
+    already on it.
+    """
+    if service_name == "argos":
+        return (
+            f"Argos could not translate: {error}. The offline language pack "
+            "may be missing or unreachable — check your connection, or add an "
+            "API key in Settings to use an online translator."
+        )
+    return (
+        f"{service_name} rejected the request: {error}. "
+        "Check the API key in Settings, or switch to Argos (offline)."
+    )
+
+
 class BaseTranslator(ABC):
     """
     Base translator interface compatible with BabelDOC integration.
@@ -109,15 +134,16 @@ class BaseTranslator(ABC):
         """
         self.lang_in = self._normalize_language_code(lang_in)
         self.lang_out = self._normalize_language_code(lang_out)
-        self.translate_call_count = 0
-        # Paragraphs this instance handed back untranslated. Read by the
-        # processor to decide whether the run is cacheable and what to tell
-        # the user; the translator itself never acts on it.
+        # Both counters are read by the processor: `translate_call_count` is
+        # the denominator of the "N of M paragraphs could not be translated"
+        # banner, `failed_translations` the numerator and the reason a run is
+        # kept out of the PDF cache. The translator itself never acts on them.
         #
-        # One instance is shared across BabelDOC's whole worker pool, so the
-        # increment is locked — `+= 1` is a read-modify-write and would drop
-        # counts under exactly the concurrent failures this exists to measure.
-        self._failure_lock = threading.Lock()
+        # One instance is shared across BabelDOC's whole worker pool, so both
+        # increments are locked — `+= 1` is a read-modify-write and would drop
+        # counts under exactly the concurrency this exists to measure.
+        self._counter_lock = threading.Lock()
+        self.translate_call_count = 0
         self.failed_translations = 0
 
         # Pop the cross-cutting callbacks before passing the rest to the
@@ -144,6 +170,18 @@ class BaseTranslator(ABC):
             cb(source, target)
         except Exception:
             logger.debug("on_paragraph_translated callback raised", exc_info=True)
+
+    def _note_translate_call(self) -> int:
+        """Count one `translate()` entry and return the new total.
+
+        Every backend calls this on the first line of `translate()`, so the
+        total covers each unit BabelDOC handed over — including the ones that
+        short-circuit on empty text, which is what makes it a usable
+        denominator for the failure banner.
+        """
+        with self._counter_lock:
+            self.translate_call_count += 1
+            return self.translate_call_count
 
     def _fire_failure_callback(self, error: BaseException, fatal: bool) -> None:
         """Best-effort: report a failed paragraph. Same contract as
@@ -286,7 +324,7 @@ class BaseTranslator(ABC):
         that to refuse caching the result, to tell the user how much of the
         document is untranslated, and to abort outright on a rejected key.
         """
-        with self._failure_lock:
+        with self._counter_lock:
             self.failed_translations += 1
             failure_number = self.failed_translations
         fatal = is_fatal_translation_error(error)

--- a/src/desktop_pdf_translator/translators/gemini_translator.py
+++ b/src/desktop_pdf_translator/translators/gemini_translator.py
@@ -50,7 +50,7 @@ class GeminiTranslator(BaseTranslator):
         logger.info(f"Gemini translator configured with model: {self.model_name}")
     
     def translate(self, text: str, **kwargs) -> str:
-        self.translate_call_count += 1
+        self._note_translate_call()
 
         try:
             processed_text = self._preprocess_text(text)
@@ -68,11 +68,23 @@ class GeminiTranslator(BaseTranslator):
                 config=self.generation_config,
             )
 
-            if response.candidates and response.candidates[0].content:
-                translated_text = response.text.strip()
-            else:
-                logger.warning("Gemini response was filtered or empty")
-                return text
+            if not (response.candidates and response.candidates[0].content):
+                # A safety filter drops `candidates` entirely. That is a failed
+                # paragraph like any other: without the funnel it came back as
+                # source text, uncounted, and the run stayed cacheable.
+                return self._handle_translation_error(
+                    RuntimeError(
+                        "Gemini returned no candidates (response filtered or "
+                        "empty)"
+                    ),
+                    text,
+                )
+
+            translated_text = response.text.strip()
+            if not translated_text:
+                return self._handle_translation_error(
+                    RuntimeError("Gemini returned an empty translation"), text
+                )
 
             result = self._postprocess_text(translated_text)
             _llm_cache_set(processed_text, result, self.lang_in, self.lang_out, "gemini", self.model_name)

--- a/src/desktop_pdf_translator/translators/openai_translator.py
+++ b/src/desktop_pdf_translator/translators/openai_translator.py
@@ -40,7 +40,7 @@ class OpenAITranslator(BaseTranslator):
         logger.info(f"OpenAI translator configured with model: {self.model}")
     
     def translate(self, text: str, **kwargs) -> str:
-        self.translate_call_count += 1
+        self._note_translate_call()
 
         try:
             processed_text = self._preprocess_text(text)
@@ -59,7 +59,15 @@ class OpenAITranslator(BaseTranslator):
                 max_tokens=self.max_tokens,
                 timeout=30,
             )
-            translated_text = response.choices[0].message.content.strip()
+            content = response.choices[0].message.content
+            translated_text = (content or "").strip()
+            if not translated_text:
+                # Already counted by the outer `except` (a None content raises
+                # AttributeError), but named explicitly so the log says what
+                # happened instead of "NoneType has no attribute 'strip'".
+                return self._handle_translation_error(
+                    RuntimeError("OpenAI returned an empty translation"), text
+                )
             result = self._postprocess_text(translated_text)
             _llm_cache_set(processed_text, result, self.lang_in, self.lang_out, "openai", self.model)
             self._fire_paragraph_callback(processed_text, result)

--- a/tests/test_translation_failure_reporting.py
+++ b/tests/test_translation_failure_reporting.py
@@ -19,11 +19,15 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import threading
+import urllib.error
+
 import pytest
 
 from desktop_pdf_translator.processors.pdf_cache import is_cacheable_artifact
 from desktop_pdf_translator.translators.base import (
     BaseTranslator,
+    describe_fatal_error,
     is_fatal_translation_error,
 )
 
@@ -96,6 +100,50 @@ def test_a_boolean_attribute_is_not_a_status():
     assert is_fatal_translation_error(_Flagged("something")) is False
 
 
+@pytest.mark.parametrize(
+    "error",
+    [
+        PermissionError(13, "Permission denied"),
+        OSError(13, "Permission denied"),
+    ],
+    ids=["PermissionError", "OSError"],
+)
+def test_a_local_permission_error_is_not_a_credentials_failure(error):
+    """These carry "Permission denied" in their text, and a Windows file lock
+    on the CTranslate2 model reaches the funnel through Argos's batch worker.
+    Reading them as a rejected key would hard-abort a run that has nothing
+    wrong with its credentials — and tell the user to check an API key."""
+    assert is_fatal_translation_error(error) is False
+
+
+def test_a_403_from_the_argos_package_index_is_still_fatal():
+    """`urllib.error.HTTPError` exposes the status as `.code`. A blocked
+    package index fails every paragraph identically, so stopping is right —
+    it is the *message* that has to know Argos has no API key."""
+    blocked = urllib.error.HTTPError("http://index", 403, "Forbidden", {}, None)
+    assert is_fatal_translation_error(blocked) is True
+
+    missing = urllib.error.HTTPError("http://index", 404, "Not Found", {}, None)
+    assert is_fatal_translation_error(missing) is False
+
+
+def test_the_fatal_sentence_does_not_offer_argos_an_api_key():
+    """Argos is reachable on the fatal path but has no credentials, so the LLM
+    sentence would name a key the user never set and tell them to switch to
+    the service they are already on."""
+    argos = describe_fatal_error("argos", RuntimeError("HTTP Error 403"))
+    # It may offer a key as the *alternative* — what it must not do is send
+    # the user to check a credential Argos never had, or tell them to switch
+    # to the service they are already running.
+    assert "Check the API key" not in argos
+    assert "switch to Argos" not in argos
+    assert "language pack" in argos
+
+    openai = describe_fatal_error("openai", RuntimeError("bad key"))
+    assert "Check the API key in Settings" in openai
+    assert "language pack" not in openai
+
+
 # ---------------------------------------------------------------------------
 # Counting and reporting
 # ---------------------------------------------------------------------------
@@ -157,6 +205,27 @@ def test_a_translator_without_the_callback_still_counts():
     translator = _StubTranslator(lang_in="en", lang_out="vi")
     translator._handle_translation_error(ValueError("x"), "text")
     assert translator.failed_translations == 1
+
+
+def test_the_call_counter_survives_the_worker_pool():
+    """`translate_call_count` is the denominator of the failure banner and one
+    translator instance serves BabelDOC's whole pool, so the increment has to
+    be locked — an unguarded `+= 1` drops counts under concurrency."""
+    translator = _StubTranslator(lang_in="en", lang_out="vi")
+    threads = 8
+    per_thread = 2_000
+
+    def hammer() -> None:
+        for _ in range(per_thread):
+            translator._note_translate_call()
+
+    workers = [threading.Thread(target=hammer) for _ in range(threads)]
+    for w in workers:
+        w.start()
+    for w in workers:
+        w.join()
+
+    assert translator.translate_call_count == threads * per_thread
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_translation_failure_reporting.py
+++ b/tests/test_translation_failure_reporting.py
@@ -1,0 +1,203 @@
+"""What happens when a paragraph can't be translated (#16).
+
+BabelDOC's `ILTranslator` logs translator errors and continues, so nothing
+downstream of `translate()` can tell a clean run from one where every
+paragraph fell back to its source text. These are the three decisions that
+close that gap, all of them pure:
+
+* classifying an error as fatal (the credentials are wrong) vs transient;
+* counting the failure and reporting it out of `BaseTranslator`;
+* refusing to put a run with failures into the whole-PDF cache.
+
+Deliberately stays out of `processors/processor.py` and
+`api/routes/translation.py`, which drag in BabelDOC + torch — the same
+trade-off `test_pdf_export_api.py` and `test_translate_language_contract.py`
+document.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from desktop_pdf_translator.processors.pdf_cache import is_cacheable_artifact
+from desktop_pdf_translator.translators.base import (
+    BaseTranslator,
+    is_fatal_translation_error,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fatal vs transient
+# ---------------------------------------------------------------------------
+
+
+class _SdkError(Exception):
+    """Stand-in for an SDK exception carrying an explicit status."""
+
+    def __init__(self, message: str, status_code: int):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class _Response:
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+
+
+class _WrappedError(Exception):
+    """Some clients hang the status off a `.response` instead."""
+
+    def __init__(self, message: str, status_code: int):
+        super().__init__(message)
+        self.response = _Response(status_code)
+
+
+@pytest.mark.parametrize("status", [401, 403])
+def test_rejected_credentials_are_fatal(status):
+    assert is_fatal_translation_error(_SdkError("nope", status)) is True
+    assert is_fatal_translation_error(_WrappedError("nope", status)) is True
+
+
+@pytest.mark.parametrize("status", [429, 500, 502, 503])
+def test_rate_limits_and_outages_are_not_fatal(status):
+    """A 429 or a 5xx may well succeed on the next paragraph — aborting the
+    whole job on one would be worse than the partial result."""
+    assert is_fatal_translation_error(_SdkError("slow down", status)) is False
+
+
+def test_network_errors_are_not_fatal():
+    assert is_fatal_translation_error(ConnectionError("connection reset")) is False
+    assert is_fatal_translation_error(TimeoutError("timed out")) is False
+
+
+def test_message_fallback_covers_sdks_without_a_status():
+    """google-genai's ClientError puts the code in its message, not an
+    attribute — so the string is the only signal available."""
+    assert is_fatal_translation_error(
+        Exception("400 API key not valid. Please pass a valid API key.")
+    )
+    assert is_fatal_translation_error(Exception("AuthenticationError: bad key"))
+
+
+def test_ordinary_failures_are_not_misread_as_fatal():
+    assert is_fatal_translation_error(ValueError("unsupported language pair")) is False
+    assert is_fatal_translation_error(RuntimeError("model returned no text")) is False
+
+
+def test_a_boolean_attribute_is_not_a_status():
+    """`getattr(error, "code", None)` finds `True` on some wrappers; `bool`
+    is an `int` subclass, and `True == 1` must not be read as a status."""
+
+    class _Flagged(Exception):
+        code = True
+
+    assert is_fatal_translation_error(_Flagged("something")) is False
+
+
+# ---------------------------------------------------------------------------
+# Counting and reporting
+# ---------------------------------------------------------------------------
+
+
+class _StubTranslator(BaseTranslator):
+    """Minimal concrete translator — `_handle_translation_error` is the shared
+    funnel every backend routes its `except` clause into."""
+
+    def _setup_translator(self, **kwargs):
+        pass
+
+    def translate(self, text: str) -> str:  # pragma: no cover - not exercised
+        return text
+
+
+def test_a_failed_paragraph_is_counted_and_still_returns_source_text():
+    """The fallback stays — BabelDOC ignores anything raised here, so raising
+    would lose the text without stopping the run. The *count* is the fix."""
+    translator = _StubTranslator(lang_in="en", lang_out="vi")
+    assert translator.failed_translations == 0
+
+    out = translator._handle_translation_error(RuntimeError("boom"), "Hello")
+
+    assert out == "Hello"
+    assert translator.failed_translations == 1
+
+
+def test_failures_are_reported_with_their_severity():
+    seen: list[tuple[str, bool]] = []
+    translator = _StubTranslator(
+        lang_in="en",
+        lang_out="vi",
+        on_translation_failed=lambda error, fatal: seen.append((str(error), fatal)),
+    )
+
+    translator._handle_translation_error(_SdkError("rate limited", 429), "a")
+    translator._handle_translation_error(_SdkError("invalid key", 401), "b")
+
+    assert [fatal for _, fatal in seen] == [False, True]
+    assert translator.failed_translations == 2
+
+
+def test_a_raising_callback_never_breaks_a_run():
+    """Same contract as the paragraph ticker: a UI hook is not allowed to take
+    the translation down with it."""
+
+    def explode(_error, _fatal):
+        raise RuntimeError("callback is broken")
+
+    translator = _StubTranslator(
+        lang_in="en", lang_out="vi", on_translation_failed=explode
+    )
+    assert translator._handle_translation_error(ValueError("x"), "text") == "text"
+    assert translator.failed_translations == 1
+
+
+def test_a_translator_without_the_callback_still_counts():
+    translator = _StubTranslator(lang_in="en", lang_out="vi")
+    translator._handle_translation_error(ValueError("x"), "text")
+    assert translator.failed_translations == 1
+
+
+# ---------------------------------------------------------------------------
+# What may enter the PDF cache
+# ---------------------------------------------------------------------------
+
+
+def _artifact(temp_translate_dir: Path) -> Path:
+    return temp_translate_dir / "paper_translated_v003.pdf"
+
+
+def test_a_clean_run_is_cacheable(temp_translate_dir: Path):
+    assert is_cacheable_artifact(
+        _artifact(temp_translate_dir), temp_translate_dir, "paper", 0
+    )
+
+
+def test_a_run_with_failures_is_never_cached(temp_translate_dir: Path):
+    """The regression this issue is about. Those paragraphs are source text,
+    so the artifact is a partly-untranslated document that looks finished —
+    and the cache key is the input's hash, so it would be served on every
+    later open until someone thought to click Re-translate."""
+    assert not is_cacheable_artifact(
+        _artifact(temp_translate_dir), temp_translate_dir, "paper", 1
+    )
+    assert not is_cacheable_artifact(
+        _artifact(temp_translate_dir), temp_translate_dir, "paper", 47
+    )
+
+
+def test_an_artifact_from_another_document_is_refused(temp_translate_dir: Path):
+    """`_find_translated_file` falls back to the newest `*.pdf` in the output
+    dir, which can be something else entirely."""
+    stray = temp_translate_dir / "something_else.pdf"
+    assert not is_cacheable_artifact(stray, temp_translate_dir, "paper", 0)
+
+
+def test_an_artifact_outside_the_job_dir_is_refused(tmp_path: Path, temp_translate_dir: Path):
+    elsewhere = tmp_path / "paper_translated_v001.pdf"
+    assert not is_cacheable_artifact(elsewhere, temp_translate_dir, "paper", 0)
+
+
+def test_a_missing_artifact_is_refused(temp_translate_dir: Path):
+    assert not is_cacheable_artifact(None, temp_translate_dir, "paper", 0)


### PR DESCRIPTION
## Summary
A rejected API key, a 429, or a network blip could not fail a translation job. The run reported "Translation complete", handed back a document that was partly still in the source language, and wrote it to the whole-PDF cache — where it was served for every later open of that file. This makes failures countable, visible, non-cacheable, and (for a rejected key) fatal.

## Root cause
Three layers each swallow the error, and together they hide it completely:

1. `translators/base.py:_handle_translation_error` returns the **original text** on any exception. Every backend's `except` clause routes into it (`openai_translator.py:68`, `gemini_translator.py:82`, `anthropic_translator.py:87`, `argos_translator.py:644,710`).
2. BabelDOC 0.5.22's `il_translator.py` catches whatever `translate()` raises and explicitly "ignore[s] error and continue[s]" — so raising from the translator would only lose the paragraph's text, not stop anything.
3. `processor.py`'s `should_cache` checked only that a rolling file existed. Nothing counted failures, so a document where every paragraph failed looked exactly like a clean run.

A bad key also *created* this situation: `PUT /config` auto-promoted `preferred_service` from Argos to the LLM whose key had just been saved, without checking it. Saving a typo moved the user off a working offline translator and onto this path.

## Approach + alternatives rejected
- **Kept the source-text fallback and added accounting around it.** Given (2), raising is strictly worse: same non-abort, but the paragraph is now blank. The fix is to make the failure *visible*, not to change what `translate()` returns.
- **Reported via a callback kwarg** (`on_translation_failed`), mirroring `on_paragraph_translated` exactly — same pop-in-`__init__`, same best-effort `try/except` around the call, same thread-to-loop bridge in the processor. Rejected polling `translator.failed_translations` from the processor: the multiplexer is parked on `events_queue.get()` and has nowhere to poll from without adding a timer.
- **Abort via the existing multiplexer queue.** The fatal handler pushes one item and the loop raises `TranslationProcessError`, which `_process_with_babeldoc` now re-raises unwrapped so its user-facing sentence isn't buried under "BabelDOC processing error: …". Rejected cancelling the chunk tasks directly from the worker thread — the loop would still be blocked on `get()`, and the existing `finally` already cancels them once the exception propagates.
- **Fatal = 401/403 only.** 429s and 5xx are explicitly *not* fatal: they can succeed on the next paragraph, and aborting a long run on one transient failure is worse than the partial result the user can now see and retry. Classification is duck-typed (`status_code` / `code` / `.response.status_code`, then a message fallback) because `base.py` must stay importable without the OpenAI / Anthropic / google-genai packages — and google-genai's `ClientError` carries the code only in its message.
- **Refused the run entirely rather than storing it flagged `partial`.** The issue offered both. Flagging means a schema migration on `index.db` plus a lookup-side filter, for an entry that no code path would ever want; not storing it costs one re-run.
- **Moved the whole cacheability rule into `pdf_cache.is_cacheable_artifact`.** It puts the rule next to the cache it guards, and — the practical reason — makes it testable: `pdf_cache.py` is one of the few modules on this path that doesn't drag in BabelDOC + torch.
- **Server-side probe before auto-promotion**, not a client-sent `validated` flag. A flag trusts the UI to be honest and, worse, would leave a *valid* key unpromoted whenever the user skipped the Validate button. The probe is one provider round-trip, only on the "first key saved while still on Argos" path, and it also covers keys arriving via `.env`. An explicit `preferred_service` in the payload is still honoured unconditionally — that's the user's own choice, not an inference.
- **Locked both counters.** `+= 1` is a read-modify-write and BabelDOC runs a whole worker pool against one translator instance, so an unlocked counter would drop exactly the concurrent failures it exists to measure. The fatal latch is under the same lock (check-then-set would otherwise let two threads both raise).

## Changes
- `translators/base.py` — `is_fatal_translation_error`, `failed_translations`, `on_translation_failed`, `_fire_failure_callback`; `_handle_translation_error` counts + reports.
- `processors/processor.py` — `_handle_translation_failure` (thread-safe), `_events_queue` publication, fatal branch in the multiplexer, cache gate, completion counts.
- `processors/events.py` — `CompletionEvent.failed_paragraphs` / `.total_paragraphs`.
- `processors/pdf_cache.py` — `is_cacheable_artifact`.
- `api/routes/config.py` — `_credentials_work`; auto-promotion gated on it.
- `desktop/src/hooks/useTranslation.ts`, `components/translation/ProgressOverlay.tsx`, `App.tsx` — the warning banner and the Retry button (Retry is Re-translate: `bypass_cache=true`, or a cached earlier result would be served instead of the re-run).
- `desktop/src/hooks/useConfig.ts` — warns when a saved key didn't validate, since the save otherwise succeeds with nothing visibly different.
- `tests/test_translation_failure_reporting.py` (new), `CLAUDE.md`.

## How tested
- `python -m pytest tests` → 77 passed (19 new). Covers 401/403 fatal via both attribute shapes; 429/5xx/network **not** fatal; the google-genai message fallback; `code = True` not misread as a status (`bool` is an `int` subclass); the counter and callback including a callback that raises; and all five cacheability outcomes. Every one fails before this change (`is_fatal_translation_error`, `failed_translations` and `is_cacheable_artifact` don't exist).
- `cd desktop && pnpm test` → 36 passed, unchanged. `pnpm build` (tsc + vite) → clean.
- `desktop_pdf_translator.processors.processor` and `api.routes.config` both imported to confirm no import-time breakage from the new names.
- **Not exercised end-to-end:** the fatal-abort path against a real 401. It needs a live provider call; the classification and the counting are unit-tested, and the wake-up is a single `call_soon_threadsafe` onto a queue the loop is already draining. Worth a manual pass with a deliberately wrong key before merge.

## Risk + rollback
Medium — this is the first change that can *stop* a translation that previously ran to completion. Two things bound it: only 401/403 abort (a rate limit still finishes with a partial result), and the classification falls back to a conservative message match rather than a broad one, so a misfire produces a job that stops with a clear message rather than a wrong document.

The other behaviour change worth watching: a run with failures is no longer cached, so a user on a flaky connection re-pays for the pipeline on the next open. That is the intended trade — the alternative is a permanently wrong cache entry.

Revert the commit to restore the old behaviour; no migration, no persisted state changes (`is_cacheable_artifact` only ever *refuses* entries that would previously have been written).

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss9ZsytfqdJiXHm77X8kC6
