### PR TITLE
chore: sync Cargo.lock with the 1.0.6 manifest version

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.0"
+version = "1.0.6"
 dependencies = [
  "env_logger",
  "log",


### PR DESCRIPTION
Loose end from #45. Cargo rewrites the lock's own package entry on the next build, so the released v1.0.6 binary is correct — but the checked-in `Cargo.lock` still said `0.1.0` against a manifest saying `1.0.6`, so every fresh build produced a spurious one-line diff.

One line. No effect on the published v1.0.6 artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01459Mgdk1BBSf19JDPFAi9D
