### PR TITLE
fix: supervise the sidecar after boot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,45 @@ Two consequences worth keeping in mind:
 
 `tests/test_sidecar_boot.py` fails if any of this regresses.
 
+### Sidecar supervision
+
+READY isn't the end of the sidecar's lifecycle — two things watch it after
+that, both in `sidecar.rs`:
+
+- A background task polls the child every `SUPERVISOR_POLL_INTERVAL` (250 ms)
+  via `try_wait()`. An exit it didn't expect emits `sidecar://exited { code }`.
+  What makes it "didn't expect": `SidecarHandle` carries a `shutting_down`
+  `AtomicBool`, and `shutdown()` sets it **before** taking the child out of the
+  mutex — that ordering is what stops an intentional kill (`restart_app`,
+  `RunEvent::ExitRequested`) from being reported as a crash. Reversing it would
+  open a window where the poller observes "child gone" without yet observing
+  "on purpose."
+- The child is confined to a Windows Job Object with
+  `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` (`confine_to_job_object`), so it dies
+  with this process no matter how this process dies — crash, Task Manager,
+  anything short of the OS itself going down. The job handle is **never
+  closed**: `KILL_ON_JOB_CLOSE` fires when the *last* handle to the job
+  closes, so leaking it for the process's lifetime is what ties the child's
+  life to ours. Both the poll and the job assignment are best-effort — neither
+  can fail sidecar startup.
+
+On the frontend, `useSidecar.ts` reacts to `sidecar://exited` by calling the
+existing `restart_app` command — a full relaunch, not an in-place respawn, for
+the same `OnceCell` reason `restart_app` itself documents. Whether it actually
+does that is gated by `lib/sidecar-recovery.ts`'s `shouldAutoRestart`: a 60 s
+cooldown recorded under a `localStorage` key, not in-memory state, because
+`app.restart()` tears down the whole JS context a module or React variable
+would otherwise live in. That timestamp is **never cleared by a successful
+`ready()`** — only elapsed time clears it. Clearing it on ready was the bug in
+the first version of this: a sidecar that crashes on every boot would
+relaunch, reach ready, wipe its own cooldown marker, and crash-loop forever
+with no way to ever reach the manual "stopped unexpectedly" screen. Leaving it
+to expire on its own still gives an unrelated crash days later a fresh
+attempt. A separate, one-shot `SIDECAR_RESTART_TOAST_KEY` — set right before
+the restart, consumed and cleared the next time `ready()` runs — is what tells
+the user their session just got reset, without reusing (and thereby
+corrupting) the cooldown key for that purpose.
+
 ### Module layout
 
 | Path | Responsibility |

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -782,6 +782,7 @@ dependencies = [
  "tauri-plugin-window-state",
  "tokio",
  "which",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -32,6 +32,7 @@ once_cell = "1"
 log = "0.4"
 env_logger = "0.11"
 which = "6"
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_System_JobObjects", "Win32_System_Threading"] }
 
 [profile.dev]
 incremental = true

--- a/desktop/src-tauri/src/sidecar.rs
+++ b/desktop/src-tauri/src/sidecar.rs
@@ -14,13 +14,14 @@
 use std::borrow::Cow;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
+use std::process::{ExitStatus, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 use std::time::Duration;
 
 use once_cell::sync::OnceCell;
 use serde::Serialize;
-use tauri::{AppHandle, Manager};
+use tauri::{AppHandle, Emitter, Manager};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::time::{sleep, Instant};
@@ -38,6 +39,9 @@ const READY_TIMEOUT: Duration = Duration::from_secs(90);
 /// FastAPI lifespan: the orphan-temp-dir sweep and decrypting the stored API
 /// keys, both of which touch a possibly-cold disk.
 const HEALTH_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// How often the post-boot supervisor polls the child for an unrequested exit.
+const SUPERVISOR_POLL_INTERVAL: Duration = Duration::from_millis(250);
 
 #[derive(Debug)]
 pub enum SidecarError {
@@ -79,16 +83,24 @@ pub struct SidecarInfo {
     pub token: String,
 }
 
+#[derive(Debug, Clone, Serialize)]
+struct ExitedPayload {
+    code: Option<i32>,
+}
+
 pub struct SidecarHandle {
     pub info: SidecarInfo,
     child: Mutex<Option<Child>>,
+    shutting_down: AtomicBool,
 }
 
 impl SidecarHandle {
     pub fn shutdown(&self) {
+        // Set before taking the child so the supervisor can never observe
+        // "child gone" without also observing "on purpose."
+        self.shutting_down.store(true, Ordering::SeqCst);
         if let Ok(mut guard) = self.child.lock() {
             if let Some(mut child) = guard.take() {
-                // start_kill is non-blocking; the OS handles teardown.
                 let _ = child.start_kill();
             }
         }
@@ -379,6 +391,73 @@ fn build_command(app: &AppHandle) -> Result<Command, SidecarError> {
     Ok(cmd)
 }
 
+/// Ties the child's lifetime to ours: if this process dies for any reason —
+/// crash, Task Manager, anything short of the OS itself going down — Windows
+/// tears the child down with it instead of orphaning it. Best-effort: a
+/// failure here is logged and otherwise ignored, never fatal to startup.
+#[cfg(windows)]
+fn confine_to_job_object(child: &Child) {
+    use windows_sys::Win32::System::JobObjects::{
+        AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+        SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+        JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    };
+
+    let Some(raw) = child.raw_handle() else {
+        log::warn!("Sidecar job confinement skipped: no process handle");
+        return;
+    };
+
+    unsafe {
+        let job = CreateJobObjectW(std::ptr::null(), std::ptr::null());
+        if job.is_null() {
+            log::warn!("Sidecar job confinement skipped: CreateJobObjectW failed");
+            return;
+        }
+
+        let mut info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+        info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+        let configured = SetInformationJobObject(
+            job,
+            JobObjectExtendedLimitInformation,
+            &info as *const _ as *const _,
+            std::mem::size_of_val(&info) as u32,
+        );
+        if configured == 0 || AssignProcessToJobObject(job, raw) == 0 {
+            log::warn!("Sidecar job confinement failed; it may outlive this app if killed abnormally");
+        }
+        // `job` is deliberately never closed: JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+        // fires when the last handle to it closes, so leaking it for the rest
+        // of this process's life is what ties the child's life to ours.
+    }
+}
+
+/// Polls `child` until it exits and reports the exit status, unless
+/// `shutting_down` says we're the ones who killed it. `None` covers both
+/// "it hasn't exited" — impossible to reach since this only returns once the
+/// child is gone — and "we already know why," e.g. `shutdown()` having taken
+/// the child out from under this loop.
+async fn unexpected_exit(
+    child: &Mutex<Option<Child>>,
+    shutting_down: &AtomicBool,
+    poll_interval: Duration,
+) -> Option<ExitStatus> {
+    loop {
+        sleep(poll_interval).await;
+        let status = match child.lock() {
+            Ok(mut guard) => match guard.as_mut() {
+                Some(c) => c.try_wait().ok().flatten(),
+                None => return None,
+            },
+            Err(_) => return None,
+        };
+        if let Some(status) = status {
+            return (!shutting_down.load(Ordering::SeqCst)).then_some(status);
+        }
+    }
+}
+
 /// Spawn the sidecar and block until it reports `READY`. Returns once `/auth/ping`
 /// answers OK. Stores the handle in the global so other code can read it.
 pub async fn spawn(app: AppHandle) -> Result<SidecarInfo, SidecarError> {
@@ -390,6 +469,9 @@ pub async fn spawn(app: AppHandle) -> Result<SidecarInfo, SidecarError> {
     command.creation_flags(0x0800_0000);
 
     let mut child = command.spawn()?;
+
+    #[cfg(windows)]
+    confine_to_job_object(&child);
 
     let stdout = child
         .stdout
@@ -455,10 +537,25 @@ pub async fn spawn(app: AppHandle) -> Result<SidecarInfo, SidecarError> {
     let handle = SidecarHandle {
         info: info.clone(),
         child: Mutex::new(Some(child)),
+        shutting_down: AtomicBool::new(false),
     };
     SIDECAR
         .set(handle)
         .map_err(|_| SidecarError::Health("sidecar handle already set".into()))?;
+
+    tokio::spawn(async move {
+        let handle = SIDECAR.get().expect("just set above");
+        let status = unexpected_exit(
+            &handle.child,
+            &handle.shutting_down,
+            SUPERVISOR_POLL_INTERVAL,
+        )
+        .await;
+        if let Some(status) = status {
+            log::warn!("Sidecar exited unexpectedly: {status}");
+            let _ = app.emit("sidecar://exited", ExitedPayload { code: status.code() });
+        }
+    });
 
     Ok(info)
 }
@@ -492,7 +589,10 @@ async fn health_check(port: u16, token: &str) -> Result<(), SidecarError> {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_ready_line, redact_ready_line};
+    use super::{parse_ready_line, redact_ready_line, unexpected_exit, Command};
+    use std::sync::atomic::AtomicBool;
+    use std::sync::Mutex;
+    use std::time::Duration;
 
     #[test]
     fn ready_line_is_logged_without_its_token() {
@@ -526,5 +626,35 @@ mod tests {
         let line = "READY token=Yd7HfSuperSecretG3";
         let err = parse_ready_line(line).expect_err("no port, so it must fail");
         assert!(!format!("{err}").contains("Yd7HfSuperSecretG3"));
+    }
+
+    #[tokio::test]
+    async fn a_crash_that_was_not_requested_is_reported_with_its_exit_code() {
+        let child = Command::new("cmd")
+            .args(["/C", "exit", "3"])
+            .spawn()
+            .expect("spawn cmd");
+        let child = Mutex::new(Some(child));
+        let shutting_down = AtomicBool::new(false);
+
+        let status = unexpected_exit(&child, &shutting_down, Duration::from_millis(10)).await;
+
+        assert_eq!(status.and_then(|s| s.code()), Some(3));
+    }
+
+    #[tokio::test]
+    async fn a_shutdown_that_already_took_the_child_produces_no_report() {
+        let child = Command::new("cmd")
+            .args(["/C", "exit", "3"])
+            .spawn()
+            .expect("spawn cmd");
+        let child = Mutex::new(Some(child));
+        let shutting_down = AtomicBool::new(true);
+        // Mirrors what `shutdown()` does before the supervisor's next poll tick.
+        child.lock().unwrap().take();
+
+        let status = unexpected_exit(&child, &shutting_down, Duration::from_millis(10)).await;
+
+        assert!(status.is_none());
     }
 }

--- a/desktop/src/components/StartupScreen.tsx
+++ b/desktop/src/components/StartupScreen.tsx
@@ -5,7 +5,10 @@ import { AlertTriangle, FileText, FolderOpen, Loader2, RotateCcw } from "lucide-
 import { Button } from "@/components/ui/button";
 
 interface StartupScreenProps {
-  state: { status: "starting" } | { status: "error"; message: string };
+  state:
+    | { status: "starting" }
+    | { status: "error"; message: string }
+    | { status: "crashed"; code: number | null };
 }
 
 /**
@@ -128,6 +131,21 @@ export function StartupScreen({ state }: StartupScreenProps) {
               <pre className="w-full whitespace-pre-wrap break-words rounded-md border border-destructive/30 bg-destructive/5 p-3 text-left text-xs text-destructive">
                 {state.message}
               </pre>
+              {actions}
+              {devHint}
+            </div>
+          )}
+          {state.status === "crashed" && (
+            <div className="flex flex-col items-center gap-3">
+              <p className="flex items-center gap-2 text-sm text-destructive">
+                <AlertTriangle className="h-4 w-4" />
+                PDFusion's background process stopped unexpectedly
+              </p>
+              <p className="text-xs text-muted-foreground">
+                It crashed again shortly after restarting, so automatic
+                recovery has been paused.
+                {state.code !== null && ` (exit code ${state.code})`}
+              </p>
               {actions}
               {devHint}
             </div>

--- a/desktop/src/hooks/useSidecar.ts
+++ b/desktop/src/hooks/useSidecar.ts
@@ -1,17 +1,20 @@
 /**
- * Tracks sidecar boot status. Returns one of: "starting" | "ready" | "error".
+ * Tracks sidecar boot status. Returns one of:
+ * "starting" | "ready" | "error" | "crashed".
  */
 
 import { useEffect, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { invoke } from "@tauri-apps/api/core";
-import { setSidecar, type SidecarInfo } from "@/lib/api-client";
+import { resetSidecar, setSidecar, type SidecarInfo } from "@/lib/api-client";
 import { waitForTauri } from "@/lib/tauri-ready";
+import { shouldAutoRestart, SIDECAR_CRASH_STORAGE_KEY } from "@/lib/sidecar-recovery";
 
 type SidecarState =
   | { status: "starting" }
   | { status: "ready"; info: SidecarInfo }
-  | { status: "error"; message: string };
+  | { status: "error"; message: string }
+  | { status: "crashed"; code: number | null };
 
 export function useSidecar(): SidecarState {
   const [state, setState] = useState<SidecarState>({ status: "starting" });
@@ -33,6 +36,7 @@ export function useSidecar(): SidecarState {
       const ready = (info: SidecarInfo) => {
         if (cancelled) return;
         setSidecar(info);
+        localStorage.removeItem(SIDECAR_CRASH_STORAGE_KEY);
         setState({ status: "ready", info });
       };
 
@@ -43,6 +47,22 @@ export function useSidecar(): SidecarState {
         subs.push(
           await listen<string>("sidecar://error", (e) => {
             if (!cancelled) setState({ status: "error", message: e.payload });
+          }),
+        );
+        subs.push(
+          await listen<{ code: number | null }>("sidecar://exited", (e) => {
+            if (cancelled) return;
+            resetSidecar();
+            const raw = localStorage.getItem(SIDECAR_CRASH_STORAGE_KEY);
+            const lastAttempt = raw === null ? null : Number(raw);
+            const now = Date.now();
+            if (shouldAutoRestart(lastAttempt, now)) {
+              localStorage.setItem(SIDECAR_CRASH_STORAGE_KEY, String(now));
+              setState({ status: "starting" });
+              void invoke("restart_app");
+            } else {
+              setState({ status: "crashed", code: e.payload.code });
+            }
           }),
         );
 

--- a/desktop/src/hooks/useSidecar.ts
+++ b/desktop/src/hooks/useSidecar.ts
@@ -6,9 +6,15 @@
 import { useEffect, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { invoke } from "@tauri-apps/api/core";
+import { toast } from "sonner";
 import { resetSidecar, setSidecar, type SidecarInfo } from "@/lib/api-client";
 import { waitForTauri } from "@/lib/tauri-ready";
-import { shouldAutoRestart, SIDECAR_CRASH_STORAGE_KEY } from "@/lib/sidecar-recovery";
+import {
+  parseCrashTimestamp,
+  shouldAutoRestart,
+  SIDECAR_CRASH_STORAGE_KEY,
+  SIDECAR_RESTART_TOAST_KEY,
+} from "@/lib/sidecar-recovery";
 
 type SidecarState =
   | { status: "starting" }
@@ -36,7 +42,14 @@ export function useSidecar(): SidecarState {
       const ready = (info: SidecarInfo) => {
         if (cancelled) return;
         setSidecar(info);
-        localStorage.removeItem(SIDECAR_CRASH_STORAGE_KEY);
+        // Consumed once, separately from SIDECAR_CRASH_STORAGE_KEY: the crash
+        // cooldown must persist across a successful boot (see
+        // shouldAutoRestart), but the toast should only ever fire once, for
+        // the boot that actually followed a crash.
+        if (localStorage.getItem(SIDECAR_RESTART_TOAST_KEY)) {
+          localStorage.removeItem(SIDECAR_RESTART_TOAST_KEY);
+          toast.error("PDFusion's background process stopped and was restarted.");
+        }
         setState({ status: "ready", info });
       };
 
@@ -53,11 +66,13 @@ export function useSidecar(): SidecarState {
           await listen<{ code: number | null }>("sidecar://exited", (e) => {
             if (cancelled) return;
             resetSidecar();
-            const raw = localStorage.getItem(SIDECAR_CRASH_STORAGE_KEY);
-            const lastAttempt = raw === null ? null : Number(raw);
+            const lastAttempt = parseCrashTimestamp(
+              localStorage.getItem(SIDECAR_CRASH_STORAGE_KEY),
+            );
             const now = Date.now();
             if (shouldAutoRestart(lastAttempt, now)) {
               localStorage.setItem(SIDECAR_CRASH_STORAGE_KEY, String(now));
+              localStorage.setItem(SIDECAR_RESTART_TOAST_KEY, "1");
               setState({ status: "starting" });
               void invoke("restart_app");
             } else {

--- a/desktop/src/lib/api-client.test.ts
+++ b/desktop/src/lib/api-client.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { getSidecar, resetSidecar, setSidecar, waitForSidecar } from "./api-client";
+
+beforeEach(() => resetSidecar());
+
+describe("sidecar info cache", () => {
+  it("returns null before any sidecar info has been set", () => {
+    expect(getSidecar()).toBeNull();
+  });
+
+  it("resolves immediately once info has already been set", async () => {
+    const info = { port: 1111, token: "a" };
+    setSidecar(info);
+    await expect(waitForSidecar()).resolves.toEqual(info);
+  });
+
+  it("queues a caller until setSidecar is called", async () => {
+    let resolved = false;
+    const pending = waitForSidecar().then((info) => {
+      resolved = true;
+      return info;
+    });
+
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    const info = { port: 2222, token: "b" };
+    setSidecar(info);
+    await expect(pending).resolves.toEqual(info);
+  });
+
+  it("resolves every caller queued before setSidecar to the same info", async () => {
+    const first = waitForSidecar();
+    const second = waitForSidecar();
+    const info = { port: 3333, token: "c" };
+    setSidecar(info);
+    await expect(first).resolves.toEqual(info);
+    await expect(second).resolves.toEqual(info);
+  });
+
+  it("makes the next waitForSidecar queue again instead of returning stale info", async () => {
+    const oldInfo = { port: 4444, token: "old" };
+    setSidecar(oldInfo);
+
+    resetSidecar();
+    expect(getSidecar()).toBeNull();
+
+    let resolved = false;
+    const pending = waitForSidecar().then((info) => {
+      resolved = true;
+      return info;
+    });
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    const newInfo = { port: 5555, token: "new" };
+    setSidecar(newInfo);
+    await expect(pending).resolves.toEqual(newInfo);
+  });
+});

--- a/desktop/src/lib/api-client.ts
+++ b/desktop/src/lib/api-client.ts
@@ -28,6 +28,12 @@ export function waitForSidecar(): Promise<SidecarInfo> {
   return new Promise((resolve) => waiters.push(resolve));
 }
 
+// waiters is always empty here — it only accumulates before the first
+// setSidecar call, which drains it immediately.
+export function resetSidecar() {
+  sidecar = null;
+}
+
 // ---------------------------------------------------------------------------
 // HTTP wrapper
 // ---------------------------------------------------------------------------

--- a/desktop/src/lib/sidecar-recovery.test.ts
+++ b/desktop/src/lib/sidecar-recovery.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { shouldAutoRestart, SIDECAR_RESTART_COOLDOWN_MS } from "./sidecar-recovery";
+import {
+  parseCrashTimestamp,
+  shouldAutoRestart,
+  SIDECAR_RESTART_COOLDOWN_MS,
+} from "./sidecar-recovery";
 
 describe("shouldAutoRestart", () => {
   it("allows an auto-restart when no crash has been recorded yet", () => {
@@ -25,5 +29,42 @@ describe("shouldAutoRestart", () => {
   it("does not allow a restart when the recorded attempt is in the future", () => {
     const now = Date.now();
     expect(shouldAutoRestart(now + 5_000, now)).toBe(false);
+  });
+
+  // Regression for the crash-loop bug: useSidecar's `ready()` must never
+  // clear the stored timestamp, or a sidecar that crashes on every boot
+  // relaunches forever instead of ever reaching the "crashed" screen.
+  it("keeps blocking a second crash even though a boot succeeded in between", () => {
+    let crashAt: number | null = null;
+
+    expect(shouldAutoRestart(crashAt, 0)).toBe(true);
+    crashAt = 0; // recorded by the exited handler before restarting
+
+    // A boot succeeds a few seconds later. Nothing clears crashAt here.
+
+    expect(shouldAutoRestart(crashAt, 5_000)).toBe(false);
+  });
+});
+
+describe("parseCrashTimestamp", () => {
+  it("returns null when nothing is stored", () => {
+    expect(parseCrashTimestamp(null)).toBeNull();
+  });
+
+  it("parses a stored timestamp", () => {
+    expect(parseCrashTimestamp("1700000000000")).toBe(1700000000000);
+  });
+
+  // Corrupted storage must not permanently disable auto-restart: Number("x")
+  // is NaN, and shouldAutoRestart(NaN, now) is false forever since every NaN
+  // comparison is false.
+  it("treats unparseable storage as no prior crash rather than NaN", () => {
+    expect(parseCrashTimestamp("not-a-number")).toBeNull();
+  });
+
+  it("treats a corrupted value that is finite as that literal timestamp", () => {
+    // Number("") coerces to 0 rather than NaN — still safe, since an
+    // ancient/epoch-zero timestamp is always well outside the cooldown.
+    expect(parseCrashTimestamp("")).toBe(0);
   });
 });

--- a/desktop/src/lib/sidecar-recovery.test.ts
+++ b/desktop/src/lib/sidecar-recovery.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldAutoRestart, SIDECAR_RESTART_COOLDOWN_MS } from "./sidecar-recovery";
+
+describe("shouldAutoRestart", () => {
+  it("allows an auto-restart when no crash has been recorded yet", () => {
+    expect(shouldAutoRestart(null, Date.now())).toBe(true);
+  });
+
+  it("refuses a second auto-restart while still inside the cooldown window", () => {
+    const now = Date.now();
+    expect(shouldAutoRestart(now - 1_000, now)).toBe(false);
+  });
+
+  it("allows an auto-restart once the cooldown window has fully elapsed", () => {
+    const now = Date.now();
+    expect(shouldAutoRestart(now - SIDECAR_RESTART_COOLDOWN_MS - 1, now)).toBe(true);
+  });
+
+  it("treats the exact cooldown boundary as still cooling down", () => {
+    const now = Date.now();
+    expect(shouldAutoRestart(now - SIDECAR_RESTART_COOLDOWN_MS, now)).toBe(false);
+  });
+
+  it("does not allow a restart when the recorded attempt is in the future", () => {
+    const now = Date.now();
+    expect(shouldAutoRestart(now + 5_000, now)).toBe(false);
+  });
+});

--- a/desktop/src/lib/sidecar-recovery.ts
+++ b/desktop/src/lib/sidecar-recovery.ts
@@ -1,8 +1,19 @@
 export const SIDECAR_CRASH_STORAGE_KEY = "pdfusion.sidecar-crash-at";
+export const SIDECAR_RESTART_TOAST_KEY = "pdfusion.sidecar-restart-toast";
 export const SIDECAR_RESTART_COOLDOWN_MS = 60_000;
 
 // lastAttempt/now are parameters rather than localStorage/Date.now() reads,
-// so this stays pure and testable with zero mocking.
+// so this stays pure and testable with zero mocking. Never cleared on a
+// successful boot — only time expires it — so a sidecar that crashes on
+// every boot still trips the brake instead of relaunching forever.
 export function shouldAutoRestart(lastAttempt: number | null, now: number): boolean {
   return lastAttempt === null || now - lastAttempt > SIDECAR_RESTART_COOLDOWN_MS;
+}
+
+// Corrupted or hand-edited storage must fail toward "no prior crash," never
+// toward a NaN that permanently reads as inside the cooldown window.
+export function parseCrashTimestamp(raw: string | null): number | null {
+  if (raw === null) return null;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : null;
 }

--- a/desktop/src/lib/sidecar-recovery.ts
+++ b/desktop/src/lib/sidecar-recovery.ts
@@ -1,0 +1,8 @@
+export const SIDECAR_CRASH_STORAGE_KEY = "pdfusion.sidecar-crash-at";
+export const SIDECAR_RESTART_COOLDOWN_MS = 60_000;
+
+// lastAttempt/now are parameters rather than localStorage/Date.now() reads,
+// so this stays pure and testable with zero mocking.
+export function shouldAutoRestart(lastAttempt: number | null, now: number): boolean {
+  return lastAttempt === null || now - lastAttempt > SIDECAR_RESTART_COOLDOWN_MS;
+}


### PR DESCRIPTION
Closes #20.

## Problem

Once the sidecar prints READY and passes its health check, nothing watches it again:

- **Sidecar crashes mid-session** → every SSE-consuming hook eventually times out with "stream ended unexpectedly," and the app is stuck until the user manually relaunches it.
- **The Tauri shell dies abnormally** (Task Manager, crash) → the child has no OS-level tie to its parent and is orphaned, left running indefinitely.

## Fix

**Rust (`sidecar.rs`)**
- A supervisor task polls the child every 250ms after boot and emits `sidecar://exited { code }` when it exits unexpectedly. A `shutting_down` flag on `SidecarHandle`, set by `shutdown()` before it kills anything, is what distinguishes an intentional kill (no event) from a genuine crash (event fired).
- The child is assigned to a Windows Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` right after spawn, so it dies with the shell no matter how the shell exits. Best-effort — never fails startup on its own. New direct dependency `windows-sys 0.61` (already resolved transitively via tokio, so no new version lands in the lock file).
- Two new `#[tokio::test]`s spawn real short-lived processes to cover the crash-vs-shutdown distinction.

**Frontend**
- `lib/sidecar-recovery.ts` (new): pure `shouldAutoRestart(lastAttempt, now)` — one free auto-restart per 60s, tracked in `localStorage` so the cooldown survives the full app relaunch.
- `useSidecar.ts`: new `sidecar://exited` listener — auto-restarts once via the existing `restart_app` command; a second crash within the cooldown window shows a `"crashed"` state instead.
- `StartupScreen.tsx`: new "stopped unexpectedly" screen for the crash-loop case, reusing the existing Retry / Show logs folder actions.
- `api-client.ts`: `resetSidecar()` so a stale port/token can't be reused across a recovery.

## Testing

- `cargo test` (src-tauri): 10/10 pass (8 existing + 2 new supervisor tests), no warnings.
- `pnpm test`: 68/68 pass (added `sidecar-recovery.test.ts`, `api-client.test.ts`).
- `pnpm build` (tsc + vite): clean.

**Not exercised by this PR** (needs a live GUI session, couldn't run headlessly in the dev sandbox):
- Job Object orphan-kill: `pnpm tauri dev`, force-kill the shell (Task Manager / `Stop-Process -Force`, not a normal close), confirm the sidecar process disappears within ~1-2s.
- End-to-end auto-restart UX: kill just the sidecar once → app should silently relaunch and reach "ready" again; kill it again within 60s → the new "stopped unexpectedly" screen should appear instead of another silent restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
